### PR TITLE
Modificando "private" para "protected"

### DIFF
--- a/src/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/src/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -16,17 +16,17 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
     /**
      * @var string
      */
-    private $version;
+    protected $version;
 
     /**
      * @var string
      */
-    private $key;
+    protected $key;
 
     /**
      * @var bool
      */
-    private $acceptBankSlip;
+    protected $acceptBankSlip;
 
     public function __construct()
     {
@@ -38,7 +38,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      * @param string   $message
      * @param int|null $level
      */
-    private function log($message, $level = null)
+    protected function log($message, $level = null)
     {
         Mage::log($message, $level, 'vindi_api.log');
     }
@@ -46,7 +46,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
     /**
      * @return \Zend_Cache_Core
      */
-    private function cache()
+    protected function cache()
     {
         return Mage::app()->getCache();
     }
@@ -58,7 +58,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      *
      * @return string
      */
-    private function buildBody($data)
+    protected function buildBody($data)
     {
         return json_encode($data);
     }
@@ -69,7 +69,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      *
      * @return string
      */
-    private function getErrorMessage($error, $endpoint)
+    protected function getErrorMessage($error, $endpoint)
     {
         return "Erro em $endpoint: {$error['id']}: {$error['parameter']} - {$error['message']}";
     }
@@ -80,7 +80,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      *
      * @return bool
      */
-    private function checkResponse($response, $endpoint)
+    protected function checkResponse($response, $endpoint)
     {
         if (isset($response['errors']) && ! empty($response['errors'])) {
             foreach ($response['errors'] as $error) {
@@ -109,7 +109,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      *
      * @return array|bool|mixed
      */
-    private function request($endpoint, $method = 'POST', $data = [], $dataToLog = null)
+    protected function request($endpoint, $method = 'POST', $data = [], $dataToLog = null)
     {
         if (! $this->key) {
             return false;
@@ -496,9 +496,9 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
             $discountPercentage = number_format(floor($discountPercentage*100)/100, 2);
 
             $discount = [[
-                        'discount_type' => 'percentage',
-                        'percentage' => $discountPercentage
-                    ]];
+                'discount_type' => 'percentage',
+                'percentage' => $discountPercentage
+            ]];
         }
 
         foreach($orderItems as $item)
@@ -525,9 +525,9 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
         $productVindiId = $this->findOrCreateProduct(array( 'sku' => 'frete', 'name' => 'Frete'));
 
         $list[] = [
-                'product_id'     => $productVindiId,
-                'pricing_schema' => ['price' => $order->getShippingAmount()],
-            ];
+            'product_id'     => $productVindiId,
+            'pricing_schema' => ['price' => $order->getShippingAmount()],
+        ];
 
         return $list;
     }


### PR DESCRIPTION
Private se faz desnecessário neste caso e atrapalha customizações do módulo com o uso das estruturas de rewrite do Magento.

As vezes é preciso customizar uma pequena parte somente para um cliente que quer a operação dele um pouco diferente, mas isto não necessariamente se aplica a todos que vão usar o módulo. Aí o correto a se fazer é criar um módulo que faz o rewrite da classe e sobrescreve apenas as partes aonde se deseja modificações. Com tudo private ou copia-se tudo que é private para a classe nova, o que não é nada bom, ou usa-se ReflactionClass, que é uma bela de uma gambiarra. Melhor deixar tudo protected, impede que os métodos e propriedades sejam chamados externamente, mas mantém uma estrutura amigável para estender a classe :)
