### PR TITLE
Altera o status do pedido de payment_review para pending_payment [MOD-23]

### DIFF
--- a/src/app/code/community/Vindi/Subscription/Model/BankSlip.php
+++ b/src/app/code/community/Vindi/Subscription/Model/BankSlip.php
@@ -106,8 +106,8 @@ class Vindi_Subscription_Model_BankSlip extends Mage_Payment_Model_Method_Abstra
             return false;
         }
 
-        $stateObject->setStatus(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW)
-            ->setState(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW);
+        $stateObject->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT)
+            ->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
 
         return $this;
     }

--- a/src/app/code/community/Vindi/Subscription/Model/CreditCard.php
+++ b/src/app/code/community/Vindi/Subscription/Model/CreditCard.php
@@ -148,8 +148,8 @@ class Vindi_Subscription_Model_CreditCard extends Mage_Payment_Model_Method_Cc
             return false;
         }
 
-        $stateObject->setStatus(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW)
-            ->setState(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW);
+        $stateObject->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT)
+            ->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
 
         return $this;
     }

--- a/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
+++ b/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
@@ -143,10 +143,10 @@ trait Vindi_Subscription_Trait_PaymentMethod
         $payment->setAmount($order->getTotalDue());
         $this->setStore($order->getStoreId());
 
-        $payment->setStatus(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW, Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW,
+        $payment->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT, Mage_Sales_Model_Order::STATE_PENDING_PAYMENT,
             'Novo período da assinatura criado', true);
-        $stateObject->setStatus(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW)
-            ->setState(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW);
+        $stateObject->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT)
+            ->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
 
         return $this;
     }
@@ -172,7 +172,7 @@ trait Vindi_Subscription_Trait_PaymentMethod
         $payment->setAmount($order->getTotalDue());
         $this->setStore($order->getStoreId());
 
-        $payment->setStatus(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW, Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW,
+        $payment->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT, Mage_Sales_Model_Order::STATE_PENDING_PAYMENT,
             'Assinatura criada', true);
 
         return true;


### PR DESCRIPTION
O Magento estava atribuindo status "payment_review" nos pedidos sem confirmação de pagamento, esse PR altera o status de "payment_review" para "pending_payment".
Precisamos alterar isso porque o status anterior só é usado em casos de suspeita de fraude, e isso limita algumas opções do pedido dentro do Magento.