### PR TITLE
[DEV-726] Fixando parcelamento do boleto em 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
-### 1.0.14 - 01/06/2016
+### 1.0.15 - 27/06/2017
+- Correção na compra de assinaturas com parcelamento no boleto.
+
+### 1.0.14 - 01/06/2017
 - Melhorias no suporte para parcelamento de assinaturas.
 
 ### 1.0.13 - 09/12/2016

--- a/src/app/code/community/Vindi/Subscription/Model/BankSlip.php
+++ b/src/app/code/community/Vindi/Subscription/Model/BankSlip.php
@@ -78,6 +78,8 @@ class Vindi_Subscription_Model_BankSlip extends Mage_Payment_Model_Method_Abstra
      */
     public function assignData($data)
     {
+        $info = $this->getInfoInstance();
+        $info->setAdditionalInformation('installments', 1);
         return $this;
     }
 

--- a/src/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/src/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.0.14</version>
+            <version>1.0.15</version>
         </Vindi_Subscription>
     </modules>
     <global>


### PR DESCRIPTION
Enviando parcela do boleto sempre como 1 pois se o plano estiver configurado com mais parcelas do lado da Vindi, a plataforma irá retornar um 422.