### PR TITLE
adicionado ambiente sandbox

### DIFF
--- a/src/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/src/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -4,9 +4,21 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
 {
 
     /**
-     * @const string API base path.
+     * @return string API base path.
      */
-    const BASE_PATH = 'https://app.vindi.com.br/api/v1/';
+    private function basePath() {
+        if('yes' == Mage::getStoreConfig('vindi_subscription/general/sandbox')) {
+            return 'https://sandbox.app.vindi.com.br/api/v1';
+        }
+
+        return 'https://app.vindi.com.br/api/v1/';
+    }
+
+
+    // /**
+    //  * @const string API base path.
+    //  */
+    // const BASE_PATH = 'https://app.vindi.com.br/api/v1/';
 
     /**
      * @var string
@@ -121,7 +133,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
             return false;
         }
 
-        $url = static::BASE_PATH . $endpoint;
+        $url = $this->basePath() . $endpoint;
         $body = $this->buildBody($data);
 
         $requestId = rand();

--- a/src/app/code/community/Vindi/Subscription/Helper/Data.php
+++ b/src/app/code/community/Vindi/Subscription/Helper/Data.php
@@ -9,6 +9,10 @@ class Vindi_Subscription_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function getKey()
     {
+        if('yes' == Mage::getStoreConfig('vindi_subscription/general/sandbox')) {
+            return Mage::getStoreConfig('vindi_subscription/general/api_key_sandbox') ?: false;
+        }
+
         return Mage::getStoreConfig('vindi_subscription/general/api_key') ?: false;
     }
 

--- a/src/app/code/community/Vindi/Subscription/etc/system.xml
+++ b/src/app/code/community/Vindi/Subscription/etc/system.xml
@@ -34,6 +34,27 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </api_key>
+                        <sandbox>
+                            <label>Usar ambiente Sandbox</label>
+                            <comment><![CDATA[
+                            Selecione 'Sim' para usar o ambiente Sandbox da Vindi.
+                            <a href="https://atendimento.vindi.com.br/hc/pt-br/articles/115012242388-Sandbox" target="_blank">Saiba mais</a>
+                            ]]></comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>2</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </sandbox>
+                        <api_key_sandbox>
+                            <label>Chave da API Sandbox</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>3</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </api_key_sandbox>
                         <send_nfe_information>
                             <label>Enviar informações para emissão de NFe's</label>
                             <comment><![CDATA[
@@ -42,7 +63,7 @@
                             ]]></comment>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>2</sort_order>
+                            <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -55,7 +76,7 @@
                             ]]></comment>
                             <frontend_type>select</frontend_type>
                             <source_model>vindi_subscription/config_shippingmethod</source_model>
-                            <sort_order>3</sort_order>
+                            <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -68,7 +89,7 @@
                             ]]></comment>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>4</sort_order>
+                            <sort_order>6</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -76,7 +97,7 @@
                         <information>
                             <label>Informações</label>
                             <frontend_model>vindi_subscription/config_information</frontend_model>
-                            <sort_order>10</sort_order>
+                            <sort_order>12</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>


### PR DESCRIPTION
## Motivação
O Magento não tem suporte ao ambiente sandbox da Vindi, isso impede que os prospects façam testes de homologação do módulo.
## Solução proposta
Sugiro adicionarmos uma opção nas configurações do módulo, com ela ativar o envio para Sandbox, com um novo campo para armazenar a chave API-Sandbox.
Com isso removemos a constante responsável pelo endereço do servidor, no lugar dela podemos usar um método que verifica se o envio para Sandbox está ativado e direciona a requisição para produção ou Sandbox.
