### PR TITLE
Exibir alguns dados da transação no Backend e Frontend

### DIFF
--- a/src/app/code/community/Vindi/Subscription/Model/BankSlip.php
+++ b/src/app/code/community/Vindi/Subscription/Model/BankSlip.php
@@ -106,8 +106,8 @@ class Vindi_Subscription_Model_BankSlip extends Mage_Payment_Model_Method_Abstra
             return false;
         }
 
-        $stateObject->setStatus(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW)
-            ->setState(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW);
+        $stateObject->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT)
+            ->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
 
         return $this;
     }

--- a/src/app/code/community/Vindi/Subscription/Model/CreditCard.php
+++ b/src/app/code/community/Vindi/Subscription/Model/CreditCard.php
@@ -148,8 +148,8 @@ class Vindi_Subscription_Model_CreditCard extends Mage_Payment_Model_Method_Cc
             return false;
         }
 
-        $stateObject->setStatus(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW)
-            ->setState(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW);
+        $stateObject->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT)
+            ->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
 
         return $this;
     }

--- a/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
+++ b/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
@@ -143,10 +143,10 @@ trait Vindi_Subscription_Trait_PaymentMethod
         $payment->setAmount($order->getTotalDue());
         $this->setStore($order->getStoreId());
 
-        $payment->setStatus(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW, Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW,
+        $payment->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT, Mage_Sales_Model_Order::STATE_PENDING_PAYMENT,
             'Novo período da assinatura criado', true);
-        $stateObject->setStatus(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW)
-            ->setState(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW);
+        $stateObject->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT)
+            ->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
 
         return $this;
     }
@@ -172,7 +172,7 @@ trait Vindi_Subscription_Trait_PaymentMethod
         $payment->setAmount($order->getTotalDue());
         $this->setStore($order->getStoreId());
 
-        $payment->setStatus(Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW, Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW,
+        $payment->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT, Mage_Sales_Model_Order::STATE_PENDING_PAYMENT,
             'Assinatura criada', true);
 
         return true;


### PR DESCRIPTION
Solicita-se que no backend do Magento seja possível visualizar:
- NSU da Transação
- Código de Autorização
- Qtdade de Parcelas

No Frontend, que seria nos emails transacionais e na conta do cliente:
- Qtdade de Parcelas

Print para melhor entendimento:
![screenshot197](https://user-images.githubusercontent.com/34916308/34448098-9d9cc85a-ecd1-11e7-8152-18d4d51658f1.png)


