### PR TITLE
Adição da Transação de Verificação

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+### 1.1.0 - 20/06/2018
+- Adição da feature Transação de Verificação para Cartões de crédito.
 
 ### 1.0.17 - 11/04/2018
 - NSU e número de parcelas de compras de cartões de crédito no administrador

--- a/src/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/src/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -269,6 +269,18 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
     }
 
     /**
+     * Make an API request to verify a Payment Profile to a Customer.
+     *
+     * @param $id integer 
+     *
+     * @return array|bool|mixed
+     */
+    public function verifyCustomerPaymentProfile($id)
+    {
+        return $this->request('payment_profiles/' . $id . '/verify', 'POST');
+    }
+
+    /**
      * @param $userCode
      *
      * @return bool

--- a/src/app/code/community/Vindi/Subscription/Model/CreditCard.php
+++ b/src/app/code/community/Vindi/Subscription/Model/CreditCard.php
@@ -215,7 +215,7 @@ class Vindi_Subscription_Model_CreditCard extends Mage_Payment_Model_Method_Cc
     public function verifyPaymentProfile($paymentProfileId)
     {
         $verify_status = $this->api()->verifyCustomerPaymentProfile($paymentProfileId);
-        return !($verify_status['status'] === 'rejected');
+        return !($verify_status['transaction']['status'] === 'rejected');
     }
     
     /**

--- a/src/app/code/community/Vindi/Subscription/Model/CreditCard.php
+++ b/src/app/code/community/Vindi/Subscription/Model/CreditCard.php
@@ -215,7 +215,7 @@ class Vindi_Subscription_Model_CreditCard extends Mage_Payment_Model_Method_Cc
     public function verifyPaymentProfile($paymentProfileId)
     {
         $verify_status = $this->api()->verifyCustomerPaymentProfile($paymentProfileId);
-        return !($verify_status['transaction']['status'] === 'rejected');
+        return ($verify_status['transaction']['status'] === 'success');
     }
     
     /**

--- a/src/app/code/community/Vindi/Subscription/Model/CreditCard.php
+++ b/src/app/code/community/Vindi/Subscription/Model/CreditCard.php
@@ -190,17 +190,34 @@ class Vindi_Subscription_Model_CreditCard extends Mage_Payment_Model_Method_Cc
             'payment_method_code'  =>  $this->getPaymentMethodCode()
         ];
 
-        $paymentProfileId = $this->api()->createCustomerPaymentProfile($creditCardData);
+        $paymentProfile = $this->api()->createCustomerPaymentProfile($creditCardData);
 
-        if ($paymentProfileId === false) {
+        if ($paymentProfile === false) {
             Mage::throwException('Erro ao informar os dados de cartão de crédito. Verifique os dados e tente novamente!');
 
             return false;
         }
 
-        return $paymentProfileId;
+        $verifyMethod = Mage::getStoreConfig('vindi_subscription/general/verify_method');
+
+        if ($verifyMethod && !$this->verifyPaymentProfile($paymentProfile['payment_profile']['id'])) {
+            Mage::throwException('Não foi possível realizar a verificação do seu cartão de crédito!');
+            return false;
+        }
+        return $paymentProfile;    
     }
 
+    /**
+     * @param int $paymentProfileId
+     *
+     * @return array|bool
+     */
+    public function verifyPaymentProfile($paymentProfileId)
+    {
+        $verify_status = $this->api()->verifyCustomerPaymentProfile($paymentProfileId);
+        return !($verify_status['status'] === 'rejected');
+    }
+    
     /**
      * @param int $customerVindiId
      */

--- a/src/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/src/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.0.16</version>
+            <version>1.1.0</version>
         </Vindi_Subscription>
     </modules>
     <global>

--- a/src/app/code/community/Vindi/Subscription/etc/system.xml
+++ b/src/app/code/community/Vindi/Subscription/etc/system.xml
@@ -9,7 +9,7 @@
     <sections>
         <vindi_subscription translate="label" module="vindi_subscription">
             <label>
-                <![CDATA[<img src="//www.vindi.com.br/image/favicon.png" style="float:left;margin-top:1px;width:16px;height:16px"/>&nbsp;Vindi Assinaturas]]></label>
+                <![CDATA[<img src="//intranet.vindi.com.br/s/pt_BR/6441/13fdbe304eeea2f7da9576ad2c58ab11249c6de6/16/_/favicon.ico" style="float:left;margin-top:1px;width:16px;height:16px"/>&nbsp;Vindi Assinaturas]]></label>
             <tab>vindi</tab>
             <frontend_type>text</frontend_type>
             <sort_order>10</sort_order>

--- a/src/app/code/community/Vindi/Subscription/etc/system.xml
+++ b/src/app/code/community/Vindi/Subscription/etc/system.xml
@@ -73,6 +73,18 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </bankslip_link_in_order_comment>
+                        <verify_method>
+                            <label>Transação de Verificação</label>
+                            <comment><![CDATA[
+                            Realiza a transação de verificação em todos os pedidos.
+                            (Taxas adicionais por verificação poderão ser cobradas)]]></comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>5</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </verify_method>
                         <information>
                             <label>Informações</label>
                             <frontend_model>vindi_subscription/config_information</frontend_model>


### PR DESCRIPTION
## Motivação
Atualmente o módulo da Vindi para Magento não possui a transação de verificação, o que impossibilita os clientes Vindi de instalarem/utilizaram essa funcionalidade.
Essa extensão pode ser indicada como um diferencial para os clientes, aumentando a confiabilitade do negócio dele tanto quanto um ganho de receita para a Vindi.

## Solução proposta
Esse PR adiciona uma opção para habilitar a função de transação de verificação da Vindi no módulo Magento, que impede a compra nas verificações rejeitadas.