### PR TITLE
Cancelamento automático de compras reprovadas

### DIFF
--- a/src/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/src/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -462,6 +462,14 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
 
     /**
      * @param $billId
+     */
+    public function deleteBill($billId)
+    {
+        $this->request("bills/{$billId}", 'DELETE');
+    }
+
+    /**
+     * @param $billId
      *
      * @return string
      */

--- a/src/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/src/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -432,7 +432,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
     public function createBill($body)
     {
         if ($response = $this->request('bills', 'POST', $body)) {
-            return $response['bill']['id'];
+            return $response['bill'];
         }
 
         return false;

--- a/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
+++ b/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
@@ -245,7 +245,7 @@ trait Vindi_Subscription_Trait_PaymentMethod
         $billId = $currentBill['id'];
 
         if ($billId) {
-            if ($currentBill['payment_method_code'] === "bank_slip" || $currentBill['status'] === "paid"){
+            if ($currentBill['payment_method_code'] === "bank_slip" || $currentBill['status'] === "paid" || $currentBill['status'] === "review"){
                 $order->setVindiBillId($billId);
                 $order->save();
                 return $billId;
@@ -263,6 +263,8 @@ trait Vindi_Subscription_Trait_PaymentMethod
         );
 
         Mage::throwException($message);
+
+        $this->api()->deleteBill($billId);
 
         return false;
     }

--- a/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
+++ b/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
@@ -242,7 +242,7 @@ trait Vindi_Subscription_Trait_PaymentMethod
         }
 
         if ($bill = $this->api()->createBill($body)) {
-            if ($bill['payment_method_code'] === "bank_slip" || $bill['status'] === "paid" || $bill['status'] === "review"){
+            if ($bill['payment_method_code'] === "bank_slip" || $bill['payment_method_code'] === "debit_card" || $bill['status'] === "paid" || $bill['status'] === "review"){
                 $order->setVindiBillId($bill['id']);
                 $order->save();
                 return $bill['id'];

--- a/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
+++ b/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
@@ -262,11 +262,9 @@ trait Vindi_Subscription_Trait_PaymentMethod
             true
         );
 
-        Mage::throwException($message);
-
         $this->api()->deleteBill($billId);
-
-        return false;
+        
+        Mage::throwException($message);
     }
 
     /**

--- a/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
+++ b/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
@@ -254,7 +254,10 @@ trait Vindi_Subscription_Trait_PaymentMethod
 
         $this->log(sprintf('Erro no pagamento do pedido %d.', $order->getId()));
 
-        $message = sprintf("Houve um problema na confirmação do pagamento, por favor entre em contato com o banco emissor do cartão. (%s)", $this->api()->lastError);
+        $errorCode = empty($currentBill['charges'])?'':$currentBill['charges']['0']['last_transaction']['gateway_response_code'];
+        $errorMessage = empty($currentBill['charges'])?'':$currentBill['charges']['0']['last_transaction']['gateway_message'];
+
+        $message = "Houve um problema na confirmação do pagamento, por favor entre em contato com o banco emissor do cartão. ($errorCode $errorMessage)";
         $payment->setStatus(
             Mage_Sales_Model_Order::STATE_CANCELED,
             Mage_Sales_Model_Order::STATE_CANCELED,
@@ -263,7 +266,7 @@ trait Vindi_Subscription_Trait_PaymentMethod
         );
 
         $this->api()->deleteBill($billId);
-        
+      
         Mage::throwException($message);
     }
 


### PR DESCRIPTION
## Motivação
O modelo de negócio atual da Vindi, requer que caso o pagamento não seja aprovado na primeira tentativa (**compras avulsas ou primeiro ciclo de uma assinatura**), a fatura e o pedido sejam cancelados.
Porém, no Magento o cliente recebe a informação que o pedido foi registrado com sucesso, e posteriormente recebe a informação de falha no pagamento.
## Solução proposta
Adicionar o cancelamento automático de faturas na Vindi após a recusa de uma transação no Magento.
As compras via **Boleto** ou _pendente de revisões do **Antifraude**_ não são canceladas automaticamente.