### PR TITLE
exibe pedido pendente na area do cliente

### DIFF
--- a/src/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/src/app/code/community/Vindi/Subscription/etc/config.xml
@@ -47,6 +47,15 @@
                 <class>Vindi_Subscription_Trait_PaymentMethod</class>
             </vindi_subscription>
         </traits>
+        <sales>
+            <order>
+                <states>
+                    <pending_payment>
+                        <visible_on_front>1</visible_on_front>
+                    </pending_payment>
+                </states>
+            </order>
+        </sales>
     </global>
     <adminhtml>
         <sales>


### PR DESCRIPTION
## Motivação
- Os pedidos com status pending_payment não aparecem na sessão orders do painel administrativo do Magento

## Solução Proposta

- Forçar a exibição desse tipo de pedido
