### PR TITLE
Adiciona método para validação da data de Expiração do Cartão de Crédito

### DIFF
--- a/src/app/code/community/Vindi/Subscription/Model/CreditCard.php
+++ b/src/app/code/community/Vindi/Subscription/Model/CreditCard.php
@@ -301,6 +301,17 @@ class Vindi_Subscription_Model_CreditCard extends Mage_Payment_Model_Method_Cc
         return $this;
     }
 
+    protected function _validateExpDate($expYear, $expMonth)
+    {
+        $date = Mage::app()->getLocale()->date();
+        if (!$expYear || !$expMonth || ($date->compareYear($expYear) == 1)
+            || ($date->compareYear($expYear) == 0 && ($date->compareMonth($expMonth) == 1))
+        ) {
+            return false;
+        }
+        return true;
+    }
+
     /**
      * @param string $errorMsg
      *

--- a/src/app/code/community/Vindi/Subscription/Model/CreditCard.php
+++ b/src/app/code/community/Vindi/Subscription/Model/CreditCard.php
@@ -290,7 +290,7 @@ class Vindi_Subscription_Model_CreditCard extends Mage_Payment_Model_Method_Cc
 
         $info->setCcNumber($ccNumber);
 
-        if (! $this->_validateExpDate($info->getCcExpYear(), $info->getCcExpMonth())) {
+        if (! $this->validateExpDate($info->getCcExpYear(), $info->getCcExpMonth())) {
             return $this->error(Mage::helper('payment')->__('Incorrect credit card expiration date.'));
         }
 
@@ -299,17 +299,6 @@ class Vindi_Subscription_Model_CreditCard extends Mage_Payment_Model_Method_Cc
         }
 
         return $this;
-    }
-
-    protected function _validateExpDate($expYear, $expMonth)
-    {
-        $date = Mage::app()->getLocale()->date();
-        if (!$expYear || !$expMonth || ($date->compareYear($expYear) == 1)
-            || ($date->compareYear($expYear) == 0 && ($date->compareMonth($expMonth) == 1))
-        ) {
-            return false;
-        }
-        return true;
     }
 
     /**

--- a/src/app/code/community/Vindi/Subscription/Model/DebitCard.php
+++ b/src/app/code/community/Vindi/Subscription/Model/DebitCard.php
@@ -237,7 +237,7 @@ class Vindi_Subscription_Model_DebitCard extends Mage_Payment_Model_Method_Cc
 
         $info->setCcNumber($dcNumber);
 
-        if (! $this->_validateExpDate($info->getCcExpYear(), $info->getCcExpMonth())) {
+        if (! $this->validateExpDate($info->getCcExpYear(), $info->getCcExpMonth())) {
             return $this->error(Mage::helper('payment')->__('Incorrect debit card expiration date.'));
         }
 
@@ -246,17 +246,6 @@ class Vindi_Subscription_Model_DebitCard extends Mage_Payment_Model_Method_Cc
         }
 
         return $this;
-    }
-
-    protected function _validateExpDate($expYear, $expMonth)
-    {
-        $date = Mage::app()->getLocale()->date();
-        if (!$expYear || !$expMonth || ($date->compareYear($expYear) == 1)
-            || ($date->compareYear($expYear) == 0 && ($date->compareMonth($expMonth) == 1))
-        ) {
-            return false;
-        }
-        return true;
     }
 
     /**

--- a/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
+++ b/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
@@ -350,4 +350,14 @@ trait Vindi_Subscription_Trait_PaymentMethod
 
         return true;
     }
+
+    protected function validateExpDate($expYear, $expMonth)
+    {
+        $date = Mage::app()->getLocale()->date();
+        return !(!$expYear
+            || !$expMonth
+            || ($date->compareYear($expYear) == 1)
+            || ($date->compareYear($expYear) == 0
+            && ($date->compareMonth($expMonth) == 1)));
+    }
 }


### PR DESCRIPTION
## Motivação
Nas renovações de assinaturas, ao executar o método **createOrder** está sendo retornado o erro de 'Data de expiração do cartão incorreta', pois o método não existe nessa classe. (apenas para cartão de débito)

## Solução Proposta
Mover o método **validateExpDate** para a classe _Perfil de Pagamentos_, tornando-o disponível tanto para Cartão de crédito como débito.