### PR TITLE
Adiciona compatibilidade com quantidade de assinaturas

### DIFF
--- a/src/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/src/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -557,22 +557,21 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
                     ]];
         }
 
-        foreach($orderItems as $item)
-        {
+        foreach ($orderItems as $item) {
             $product = Mage::getModel('catalog/product')->load($item->getProductId());
-            if ($product->getTypeID() !== 'subscription') {
-                Mage::throwException("O produto {$item->getName()} não é uma assinatura.");
+            $productVindiId = $this->findOrCreateProduct(array('sku' => $item->getSku(), 'name' => $item->getName()));
+            $cycles         = null;
 
-                return false;
-            }
+            for ($i = 1; $i <= $item->getQtyOrdered(); $i++) {
+                if ($product->getTypeID() !== 'subscription') {
+                    $cycles = 1;
+                }
 
-            $productVindiId = $this->findOrCreateProduct(array( 'sku' => $item->getSku(), 'name' => $item->getName()));
-
-            for ($i=1; $i <= $item->getQtyOrdered() ; $i++) {
                 $list[] = [
                     'product_id'     => $productVindiId,
+                    'cycles'         => $cycles,
                     'pricing_schema' => ['price' => $item->getPrice()],
-                    'discounts'       => $discount,
+                    'discounts'      => $discount,
                 ];
             }
         }

--- a/src/app/code/community/Vindi/Subscription/Model/Observer.php
+++ b/src/app/code/community/Vindi/Subscription/Model/Observer.php
@@ -31,7 +31,7 @@ class Vindi_Subscription_Model_Observer
         $this->validateOrder($observer);
     }
 
-    public function getCartItems
+    public function getCartItems ()
     {
         return Mage::getSingleton('checkout/session')->getQuote();
     }

--- a/src/app/code/community/Vindi/Subscription/Model/Observer.php
+++ b/src/app/code/community/Vindi/Subscription/Model/Observer.php
@@ -24,23 +24,27 @@ class Vindi_Subscription_Model_Observer
             return;
         }
         
-        if ($this->countSubscriptions($quote) <= 1) {
+        if ($this->countSubscriptions($this->getCartItems()) <= 1) {
             return;
         }
 
         $this->validateOrder($observer);
     }
 
+    public function getCartItems
+    {
+        return Mage::getSingleton('checkout/session')->getQuote();
+    }
+
     public function validateOrder ($observer) 
     {
         $data = $observer->getEvent()->getInfo();
-        $quote = Mage::getSingleton('checkout/session')->getQuote();
         $lastVindiPlanId  = null;
 
         foreach ($data as $itemId => $itemInfo) {
-            $item = $quote->getItemById($itemId);
+            $item = $this->getCartItems()->getItemById($itemId);
 
-            if (!$item || !$quote->getItemsCount() || !$this->isSubscription($item->getProduct())) {
+            if (!$item || !$this->getCartItems()->getItemsCount() || !$this->isSubscription($item->getProduct())) {
                 continue;
             }
 
@@ -68,9 +72,7 @@ class Vindi_Subscription_Model_Observer
             return;
         }
 
-        $quote = Mage::getSingleton('checkout/session')->getQuote();
-
-        if (!$quote->getItemsCount() && $quote->getItemsSummaryQty() === 1) {
+        if (!$this->getCartItems()->getItemsCount() && $this->getCartItems()->getItemsSummaryQty() === 1) {
             return;
         }
 

--- a/src/app/code/community/Vindi/Subscription/Model/Observer.php
+++ b/src/app/code/community/Vindi/Subscription/Model/Observer.php
@@ -27,12 +27,11 @@ class Vindi_Subscription_Model_Observer
         $this->validateOrder();
     }
 
-    public function validateOrder ($observer) 
+    public function validateOrder () 
     {
         $cart = Mage::getSingleton('checkout/session')->getQuote()->getAllItems();
 
-        foreach ( $cart as $item )
-        {
+        foreach ( $cart as $item ) {
             if ($item->getProduct()->getData('type_id') === 'simple')
                 continue;
 


### PR DESCRIPTION
## Motivação
Atualmente não é possível realizar a compra de mais de 1 item do tipo assinatura no Magento mesmo que sejam do mesmo Plano.

## Solução Proposta
Criação de um método para validação do carrinho, que bloqueie apenas a compra de assinaturas com recorrências diferentes.