### PR TITLE
Remove GET adicional na fatura após finalizar pedido

### DIFF
--- a/src/app/code/community/Vindi/Subscription/Model/BankSlip.php
+++ b/src/app/code/community/Vindi/Subscription/Model/BankSlip.php
@@ -99,12 +99,12 @@ class Vindi_Subscription_Model_BankSlip extends Mage_Payment_Model_Method_Abstra
         $customerId = $this->createCustomer($order, $customer);
 
         if ($this->isSingleOrder($order)) {
-            $result = $this->processSinglePayment($payment, $order, $customerId);
+            $bill = $this->processSinglePayment($payment, $order, $customerId);
         } else {
-            $result = $this->processSubscription($payment, $order, $customerId);
+            $bill = $this->processSubscription($payment, $order, $customerId);
         }
 
-        if (! $result) {
+        if (! $bill) {
             return false;
         }
 

--- a/src/app/code/community/Vindi/Subscription/Model/DebitCard.php
+++ b/src/app/code/community/Vindi/Subscription/Model/DebitCard.php
@@ -137,12 +137,12 @@ class Vindi_Subscription_Model_DebitCard extends Mage_Payment_Model_Method_Cc
         }
 
         if ($this->isSingleOrder($order)) {
-            $billId = $this->processSinglePayment($payment, $order, $customerId);
+            $bill = $this->processSinglePayment($payment, $order, $customerId);
         } else {
-            $billId = $this->processSubscription($payment, $order, $customerId);
+            $bill = $this->processSubscription($payment, $order, $customerId);
         }
 
-        if (! $billId) {
+        if (! $bill) {
             return false;
         }
 

--- a/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
+++ b/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
@@ -245,7 +245,7 @@ trait Vindi_Subscription_Trait_PaymentMethod
             if ($bill['payment_method_code'] === "bank_slip" || $bill['payment_method_code'] === "debit_card" || $bill['status'] === "paid" || $bill['status'] === "review"){
                 $order->setVindiBillId($bill['id']);
                 $order->save();
-                return $bill['id'];
+                return $bill;
             }
             $this->api()->deleteBill($bill['id']);
         }


### PR DESCRIPTION
## Motivação
Ao finalizar um pedido, o módulo realiza uma requisição adicional na Vindi para consultar o status da fatura, porém, com o método **Cartão de Crédito**  o status já é recebido na requisição inicial, e pode ser consultado.

## Solução Proposta
Remover a consulta realiza na fatura da Vindi após a finalização do pedido, criando um método para atualizar o status do pedido/invoice durante o checkout.