### PR TITLE
Remove validação da data de expiração duplicada

### DIFF
--- a/src/app/code/community/Vindi/Subscription/Model/CreditCard.php
+++ b/src/app/code/community/Vindi/Subscription/Model/CreditCard.php
@@ -290,10 +290,6 @@ class Vindi_Subscription_Model_CreditCard extends Mage_Payment_Model_Method_Cc
 
         $info->setCcNumber($ccNumber);
 
-        if (! $this->validateExpDate($info->getCcExpYear(), $info->getCcExpMonth())) {
-            return $this->error(Mage::helper('payment')->__('Incorrect credit card expiration date.'));
-        }
-
         if (! array_key_exists($info->getCcType(), $availableTypes)) {
             return $this->error(Mage::helper('payment')->__('Credit card type is not allowed for this payment method.'));
         }

--- a/src/app/code/community/Vindi/Subscription/Model/DebitCard.php
+++ b/src/app/code/community/Vindi/Subscription/Model/DebitCard.php
@@ -237,10 +237,6 @@ class Vindi_Subscription_Model_DebitCard extends Mage_Payment_Model_Method_Cc
 
         $info->setCcNumber($dcNumber);
 
-        if (! $this->validateExpDate($info->getCcExpYear(), $info->getCcExpMonth())) {
-            return $this->error(Mage::helper('payment')->__('Incorrect debit card expiration date.'));
-        }
-
         if (! array_key_exists($info->getCcType(), $availableTypes)) {
             return $this->error(Mage::helper('payment')->__('Debit card type is not allowed for this payment method.'));
         }

--- a/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
+++ b/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
@@ -350,14 +350,4 @@ trait Vindi_Subscription_Trait_PaymentMethod
 
         return true;
     }
-
-    protected function validateExpDate($expYear, $expMonth)
-    {
-        $date = Mage::app()->getLocale()->date();
-        return !(!$expYear
-            || !$expMonth
-            || ($date->compareYear($expYear) == 1)
-            || ($date->compareYear($expYear) == 0
-            && ($date->compareMonth($expMonth) == 1)));
-    }
 }


### PR DESCRIPTION
## Motivação
Já existe uma validação da data de Expiração nativa no Magento, que é executada via _javascript_ durante o checkout.
O método validateExpDate refaz essa validação, realizando também durante o tratamento dos Webhooks.
Se o método de pagamento de uma fatura for alterado, o **payment_profile** receberá o valor **null**, e irá falhar nessa validação, impedindo a renovação correta dos pedidos no Magento.

## Solução Proposta
Remover o método implementado pela Vindi.