### PR TITLE
Ajusta installments compra variada

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Notas das versões
 
+## [1.2.0 - 10/08/2018](https://github.com/vindi/vindi-magento/releases/tag/1.2.0)
+
+### Adicionado
+- Adiciona exibição de pedidos com status pendente no painel do cliente
+- Adiciona compatibilidade com quantidade de assinaturas
+
+### Ajustado
+- Ajusta parcelas para compras variadas (produtos recorrentes + produtos avulsos)
+
+### Removido
+- Remove verificação da data de expiração do cartão nas renovações via Webhooks
+- Remove consulta adicional na fatura da Vindi após finalização da compra
+
+
 ## [1.1.0 - 20/06/2018](https://github.com/vindi/vindi-magento/releases/tag/1.1.0)
 
 ### Adicionado

--- a/src/app/code/community/Vindi/Subscription/Block/Form/Cc.php
+++ b/src/app/code/community/Vindi/Subscription/Block/Form/Cc.php
@@ -77,6 +77,8 @@ class Vindi_Subscription_Block_Form_Cc extends Mage_Payment_Block_Form_Cc
         foreach($quote->getAllVisibleItems() as $item){
             $product = Mage::getModel('catalog/product')->load($item->getProductId());
             $plan = $product->getData('vindi_subscription_plan');
+            if (!empty($plan))
+                break;
         }
 
         $installments = $this->api()->getPlanInstallments($plan);

--- a/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
+++ b/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
@@ -276,9 +276,8 @@ trait Vindi_Subscription_Trait_PaymentMethod
             $plan = (!empty(Mage::getModel('catalog/product')->load($item->getProductId())->getData('vindi_subscription_plan'))) ? 
                     Mage::getModel('catalog/product')->load($item->getProductId())->getData('vindi_subscription_plan')  : null;
 
-            if (null === $plan)
-                continue;
-            break;
+            if (null !== $plan)
+                break;
         }
 
         $productItems = $this->api()->buildPlanItemsForSubscription($order);

--- a/src/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/src/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </Vindi_Subscription>
     </modules>
     <global>


### PR DESCRIPTION
## Motivação
Após a implementação das quantidades de assinaturas, e compras variáveis (simples/recorrentes); O plano não está sendo obtido caso o primeiro produto do carrinho seja um produto simples, pois a verificação é realizada apenas no primeiro item do carrinho.

## Solução Proposta
 A primeira quantidade de parcelas válida é informada, e caso não seja possível parcelar, é retornado **null** (à vista).
