### PR TITLE
Adiciona envio de taxa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Notas das versões
 
+## [1.3.0 - 20/08/2018](https://github.com/vindi/vindi-magento/releases/tag/1.3.0)
+
+### Adicionado
+- Adiciona compatibilidade com taxas do Magento
+
+### Ajustado
+- Ajusta retorno do método de criação de assinaturas
+
+
+## [1.2.0 - 10/08/2018](https://github.com/vindi/vindi-magento/releases/tag/1.2.0)
+
+### Adicionado
+- Adiciona exibição de pedidos com status pendente no painel do cliente
+- Adiciona compatibilidade com quantidade de assinaturas
+
+### Ajustado
+- Ajusta parcelas para compras variadas (produtos recorrentes + produtos avulsos)
+
+### Removido
+- Remove verificação da data de expiração do cartão nas renovações via Webhooks
+- Remove consulta adicional na fatura da Vindi após finalização da compra
+
+
 ## [1.1.0 - 20/06/2018](https://github.com/vindi/vindi-magento/releases/tag/1.1.0)
 
 ### Adicionado

--- a/src/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/src/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -541,7 +541,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      */
     public function buildPlanItemsForSubscription($order)
     {
-        $list = [];
+        $list = array();
         $orderItems = $order->getItemsCollection();
         $orderSubtotal = $order->getQuote()->getSubtotal();
         $orderDiscount = $order->getDiscountAmount() * -1;
@@ -551,10 +551,10 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
             $discountPercentage = $orderDiscount * 100 / $orderSubtotal;
             $discountPercentage = number_format(floor($discountPercentage*100)/100, 2);
 
-            $discount = [[
+            $discount = array(array(
                         'discount_type' => 'percentage',
                         'percentage' => $discountPercentage
-                    ]];
+                    ));
         }
 
         foreach ($orderItems as $item) {
@@ -565,29 +565,29 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
                     $cycles = 1;
                 }
 
-                $list[] = [
+                $list[] = array(
                     'product_id'     => $this->findOrCreateProduct(array(
                     	'sku' => $item->getSku(),
                     	'name' => $item->getName())),
                     'cycles'         => $cycles,
-                    'pricing_schema' => ['price' => $item->getPrice()],
+                    'pricing_schema' => array('price' => $item->getPrice()),
                     'discounts'      => $discount,
-                ];
+                );
             }
         }
 
         if ($order->getShippingAmount() > 0) {
-            $list[] = [
+            $list[] = array(
                 'product_id'     => $this->findOrCreateProduct(array( 'sku' => 'frete', 'name' => 'Frete')),
-                'pricing_schema' => ['price' => $order->getShippingAmount()],
-            ];
+                'pricing_schema' => array('price' => $order->getShippingAmount()),
+            );
         }
         
         if (isset($order->getQuote()->getTotals()["tax"])) {
-            $list[] = [
+            $list[] = array(
                 'product_id'     => $this->findOrCreateProduct(array( 'sku' => 'taxa', 'name' => 'Taxa')),
-                'pricing_schema' => ['price' => $order->getQuote()->getTotals()['tax']->getData('value')],
-            ];
+                'pricing_schema' => array('price' => $order->getQuote()->getTotals()['tax']->getData('value')),
+            );
         }
 
         return $list;

--- a/src/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/src/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.1.0</version>
+            <version>1.3.0</version>
         </Vindi_Subscription>
     </modules>
     <global>


### PR DESCRIPTION
## Motivação
A Taxa do Magento não estava sendo enviada para a Vindi, causando a divergência de valores cobrados entre Vindi x Magento.

## Solução Proposta
Adicionar método de criação de um produto com o nome de Taxa, que recebe o valor de todas as taxas no carrinho.