### PR TITLE
Ajusta método de criação de assinaturas

### DIFF
--- a/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
+++ b/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
@@ -201,7 +201,7 @@ trait Vindi_Subscription_Trait_PaymentMethod
         $payment->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT, Mage_Sales_Model_Order::STATE_PENDING_PAYMENT,
             'Assinatura criada', true);
 
-        return $order->getVindiBillId();
+        return $subscription['bill'];
     }
 
     /**


### PR DESCRIPTION
## Motivação
Com a remoção do GET adicional na criação das faturas #61, o retorno da assinatura não está sendo tratado corretamente, consequentemente deixando o pedido com status **pagamento pendente**.

## Solução Proposta
Retornar a fatura completa contida na assinatura, possibilitando a validação do status e demais informações presentes.