### PR TITLE
Altera validação no método de criação de taxas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [1.3.1 - 23/08/2018](https://github.com/vindi/vindi-magento/releases/tag/1.3.1)
+
+### Ajustado
+- Ajusta validação das taxas
+
+
 ## [1.3.0 - 20/08/2018](https://github.com/vindi/vindi-magento/releases/tag/1.3.0)
 
 ### Adicionado

--- a/src/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/src/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -583,7 +583,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
             );
         }
         
-        if (isset($order->getQuote()->getTotals()["tax"])) {
+        if (array_key_exists('tax', $order->getQuote()->getTotals())) {
             $list[] = array(
                 'product_id'     => $this->findOrCreateProduct(array( 'sku' => 'taxa', 'name' => 'Taxa')),
                 'pricing_schema' => array('price' => $order->getQuote()->getTotals()['tax']->getData('value')),

--- a/src/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/src/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.3.0</version>
+            <version>1.3.1</version>
         </Vindi_Subscription>
     </modules>
     <global>


### PR DESCRIPTION
## Motivação
A validação das taxas está retornando um **fatal error** que não foi reproduzido nos testes.

## Solução Proposta
Alterar o modo de validação de **isset** para **array_key_exists**.