### PR TITLE
Corrige validação no pagamento dos pedidos

### DIFF
--- a/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
+++ b/src/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
@@ -242,7 +242,7 @@ trait Vindi_Subscription_Trait_PaymentMethod
         }
 
         if ($bill = $this->api()->createBill($body)) {
-            if ($bill['payment_method_code'] === "bank_slip" || $bill['payment_method_code'] === "debit_card" || $bill['status'] === "paid" || $bill['status'] === "review"){
+            if ($body['payment_method_code'] === "bank_slip" || $body['payment_method_code'] === "debit_card" || $bill['status'] === "paid" || $bill['status'] === "review"){
                 $order->setVindiBillId($bill['id']);
                 $order->save();
                 return $bill;


### PR DESCRIPTION
## Motivação
A variável `bill` não continha a informação de método de pagamento explícita.

## Solução Proposta
Utilizar a variável `body` para obter essa informação.