### PR TITLE
Ajusta validação de produtos no carrinho

### DIFF
--- a/app/code/community/Vindi/Subscription/Model/Observer.php
+++ b/app/code/community/Vindi/Subscription/Model/Observer.php
@@ -31,11 +31,11 @@ class Vindi_Subscription_Model_Observer
     {
         $cart = Mage::getSingleton('checkout/session')->getQuote()->getAllItems();
 
-        foreach ( $cart as $item ) {
+        foreach ($cart as $item) {
             if ($item->getProduct()->getData('type_id') === 'simple')
                 continue;
 
-            if ($lastProduct == null && $item->getProduct()->getData('type_id') === 'subscription') {
+            if (!isset($lastProduct) && $item->getProduct()->getData('type_id') === 'subscription') {
                 $lastProduct = $item->getProduct()->getData('type_id');
                 continue;
             }


### PR DESCRIPTION
## Motivação
A descrição não estava funcionando corretamente, pois a princípio o valor de _lastProduct_ não está setado.

## Solução Proposta
Alterar a validação para isset(lastProduct) para garantir que não será gerado nenhum erro.