### PR TITLE
Adiciona suporte à suspeita de fraude com aprovação via Konduto

### DIFF
--- a/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
+++ b/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
@@ -245,7 +245,8 @@ trait Vindi_Subscription_Trait_PaymentMethod
             if ($body['payment_method_code'] === "bank_slip"
                 || $body['payment_method_code'] === "debit_card"
                 || $bill['status'] === "paid"
-                || $bill['status'] === "review") {
+                || $bill['status'] === "review")
+                || $bill['charges'][0]['status'] === "fraud_review") {
                 $order->setVindiBillId($bill['id']);
                 $order->save();
                 return $bill;

--- a/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
+++ b/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
@@ -245,7 +245,7 @@ trait Vindi_Subscription_Trait_PaymentMethod
             if ($body['payment_method_code'] === "bank_slip"
                 || $body['payment_method_code'] === "debit_card"
                 || $bill['status'] === "paid"
-                || $bill['status'] === "review")
+                || $bill['status'] === "review") 
                 || $bill['charges'][0]['status'] === "fraud_review") {
                 $order->setVindiBillId($bill['id']);
                 $order->save();


### PR DESCRIPTION
## Issue
[#1742](https://github.com/vindi/recurrent/issues/1742)

## Motivação
Não está sendo possível realizar compras quando o antifraude [Konduto](https://www.konduto.com/) declara uma transação como "**suspeita de fraude**".
Atualmente, o cliente recebe a informação que houve um erro ao processar o pagamento e a compra, cancelando a compra, pois o **status da cobrança** não é tratado no Magento;
Quando a transação é categorizada como suspeita, é necessário aguardar uma análise da [Konduto](https://www.konduto.com/), que posteriormente atualiza a transação para *aprovada* **ou** *rejeitada*.

## Solução Proposta
Adicionar a validação para o status '**fraund_review**', dentro da **Charge** da **Fatura** atual.