### PR TITLE
Aplica ajuste do Marketplace

### DIFF
--- a/app/code/community/Vindi/Subscription/Helper/WebhookHandler.php
+++ b/app/code/community/Vindi/Subscription/Helper/WebhookHandler.php
@@ -13,10 +13,9 @@ class Vindi_Subscription_Helper_WebhookHandler extends Mage_Core_Helper_Abstract
         switch ($level) {
             case 4:
                 http_response_code(422);
-                exit($message);
+                return false;
                 break;
             case 5:
-                echo $message;
                 return false;
                 break;
             default:
@@ -55,7 +54,7 @@ class Vindi_Subscription_Helper_WebhookHandler extends Mage_Core_Helper_Abstract
 
             case 'test':
                 $this->log('Evento de teste do webhook.');
-                exit('1');
+                return false;
             case 'bill_created':
                 return $this->billCreated($data);
             case 'bill_paid':
@@ -64,7 +63,6 @@ class Vindi_Subscription_Helper_WebhookHandler extends Mage_Core_Helper_Abstract
                 return $this->chargeRejected($data);
             default:
                 $this->log(sprintf('Evento do webhook ignorado pelo plugin: "%s".', $type), 5);
-                exit('0');
         }
     }
 

--- a/app/code/community/Vindi/Subscription/Model/Observer.php
+++ b/app/code/community/Vindi/Subscription/Model/Observer.php
@@ -100,7 +100,6 @@ class Vindi_Subscription_Model_Observer
         Mage::getSingleton('core/session')->addNotice($message);
         Mage::app()->getFrontController()->getResponse()->setRedirect(Mage::getUrl('checkout/cart'));
         Mage::app()->getResponse()->sendResponse();
-        exit;
     }
 
     /**

--- a/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
+++ b/app/code/community/Vindi/Subscription/Trait/PaymentMethod.php
@@ -245,7 +245,7 @@ trait Vindi_Subscription_Trait_PaymentMethod
             if ($body['payment_method_code'] === "bank_slip"
                 || $body['payment_method_code'] === "debit_card"
                 || $bill['status'] === "paid"
-                || $bill['status'] === "review") 
+                || $bill['status'] === "review"
                 || $bill['charges'][0]['status'] === "fraud_review") {
                 $order->setVindiBillId($bill['id']);
                 $order->save();


### PR DESCRIPTION
## Motivação
O módulo está sendo recusado pelo Marketplace por erros 'legado'.

## Solução Proposta
Remover as chamadas do método **exit** utilizado para jogar uma mensagem de erro por padrão no Magento.
