### PR TITLE
Atualiza debit card redirect_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Notas das versões
 
-## [1.3.4 - 27/12/2018](https://github.com/vindi/vindi-magento/releases/tag/1.3.4)
+## [1.3.4 - 11/01/2019](https://github.com/vindi/vindi-magento/releases/tag/1.3.4)
 
 ### Ajustado
 - Ajusta a função getDebitCardRedirectUrl para pegar o redirect_url em vez de authorization_url

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Notas das versões
 
+## [1.3.4 - 27/12/2018](https://github.com/vindi/vindi-magento/releases/tag/1.3.4)
+
+### Ajustado
+- Ajusta a função getDebitCardRedirectUrl para pegar o redirect_url em vez de authorization_url
+
 ## [1.3.3 - 27/12/2018](https://github.com/vindi/vindi-magento/releases/tag/1.3.3)
 
 ### Corrigido

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -773,7 +773,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
             'id' => $bill['bill']['payment_profile']['id']
         ]);
 
-        return $charged['charge']['last_transaction']['gateway_response_fields']['authorization_url'];
+        return $charged['charge']['last_transaction']['gateway_response_fields']['redirect_url'];
 
     }
 }

--- a/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.3.3</version>
+            <version>1.3.4</version>
         </Vindi_Subscription>
     </modules>
     <global>


### PR DESCRIPTION
## Motivação
Foi feita uma alteração no recurrent para viabilizar o uso de cartão de débito via api. Nessa alteração, retornamos o atributo `redirect_url` que aponta para a rota responsável por criar a transação de autorização, mantendo os headers da requisição do usuário final de ponta a ponta.

## Solução Proposta

Atualizar a função `getDebitCardRedirectUrl` para pegar o `redirect_url` em vez de `authorization_url` no `gateway_response_fields`