### PR TITLE
Refatoração das classes de Webhook

### DIFF
--- a/app/code/community/Vindi/Subscription/Helper/Bill.php
+++ b/app/code/community/Vindi/Subscription/Helper/Bill.php
@@ -30,10 +30,6 @@ class Vindi_Subscription_Helper_Bill
 			$this->logger->log('Impossível gerar novo pedido!', 4);
 			return false;
 		}
-
-		// Remove os produtos inativos
-		$this->orderHandler->updateProductsList($order, $vindiData, $bill['charges']);
-
 		return $this->orderHandler->renewalOrder($order, $vindiData);
 	}
 
@@ -64,22 +60,17 @@ class Vindi_Subscription_Helper_Bill
 		$vindiData = [
 			'bill'     => [
 				'id'           => $data['bill']['id'],
-				'amount'       => $data['bill']['amount'],
+				'amount'       => $data['bill']['amout'],
 				'subscription' => $data['bill']['subscription']['id'],
 				'cycle'        => $data['bill']['period']['cycle']
 			],
 			'products' => [],
 			'shipping' => [],
-			'taxes'    => [],
 		];
 
 		foreach ($data['bill']['bill_items'] as $billItem) {
 			if ($billItem['product']['code'] == 'frete') {
 				$vindiData['shipping'] = $billItem;
-				continue;
-			}
-			if ($billItem['product']['code'] == 'taxa') {
-				$vindiData['taxes'][] = $billItem;
 				continue;
 			}
 			$vindiData['products'][] = $billItem;

--- a/app/code/community/Vindi/Subscription/Helper/Bill.php
+++ b/app/code/community/Vindi/Subscription/Helper/Bill.php
@@ -1,0 +1,107 @@
+<?php
+
+class Vindi_Subscription_Helper_Bill
+{
+	protected $logger;
+	protected $orderHandler;
+
+	public function __construct() {
+		$this->logger       = Mage::helper('vindi_subscription/logger');
+		$this->orderHandler = Mage::helper('vindi_subscription/order');
+	}
+
+	/**
+	 * Trata Webhook 'bill_created'
+	 * A fatura pode estar relacionada a uma assinatura ou uma compra avulsa
+	 *
+	 * @param array $data
+	 *
+	 * @return bool
+	 */
+	public function processBillCreated($data)
+	{
+		$bill = $data['bill'];
+		$vindiData = $this->loadBillData($data);
+		$lastOrder = $this->getLastPeriod($data);
+
+		$order = $this->orderHandler->createOrder($lastOrder, $vindiData);
+
+		// Remove os produtos inativos
+		$this->orderHandler->updateProductsList($order, $vindiData, $bill['charges']);
+
+		if (!$order) {
+			$this->logger->log('Impossível gerar novo pedido!', 4);
+			return false;
+		}
+		return $this->orderHandler->renewalOrder($order, $vindiData);
+	}
+
+	/**
+	 * Retorna o último pedido referente a assinatura
+	 *
+	 * @param array $data
+	 *
+	 * @return bool|Mage_Sales_Model_Order
+	 */
+	public function getLastPeriod($data)
+	{
+		$currentPeriod = $data['bill']['period']['cycle'];
+		$subscriptionId = $data['bill']['subscription']['id'];
+		return $this->orderHandler->getSubscriptionOrder($subscriptionId, $currentPeriod - 1);
+	}
+
+	/**
+	 * Carrega os dados do Webhook de fatura criada
+	 *
+	 * @param array $data
+	 *
+	 * @return array
+	 */       
+	public function loadBillData($data)
+	{
+		$vindiData = [
+			'bill'     => [
+				'id'           => $data['bill']['id'],
+				'amount'       => $data['bill']['amount'],
+				'subscription' => $data['bill']['subscription']['id'],
+				'cycle'        => $data['bill']['period']['cycle']
+			],
+			'products' => [],
+			'shipping' => [],
+			'taxes'    => [],
+		];
+
+		foreach ($data['bill']['bill_items'] as $billItem) {
+			if ($billItem['product']['code'] == 'frete') {
+				$vindiData['shipping'] = $billItem;
+			}
+			elseif ($billItem['product']['code'] == 'taxa') {
+				$vindiData['taxes'][] = $billItem;
+			}
+			else {
+				$vindiData['products'][] = $billItem;
+			}
+		}
+		return $vindiData;
+	}
+
+	/**
+	 * Trata o Webhook 'bill_paid'
+	 * A fatura pode estar relacionada a uma assinatura ou uma compra avulsa
+	 *
+	 * @param array $data
+	 *
+	 * @return bool
+	 */
+	public function processBillPaid($data)
+	{
+		$order = $this->orderHandler->getOrder($data);
+		if (! $order) {
+			$this->logger->log(sprintf(
+				'Ainda não existe um pedido para ciclo %s da assinatura: %d.',
+				$data['bill']['period']['cycle'], $data['bill']['subscription']['id']), 4);
+			return false;
+		}
+		return $this->orderHandler->createInvoice($order);
+	}
+}

--- a/app/code/community/Vindi/Subscription/Helper/Bill.php
+++ b/app/code/community/Vindi/Subscription/Helper/Bill.php
@@ -47,7 +47,8 @@ class Vindi_Subscription_Helper_Bill
 	{
 		$currentPeriod = $data['bill']['period']['cycle'];
 		$subscriptionId = $data['bill']['subscription']['id'];
-		return $this->orderHandler->getSubscriptionOrder($subscriptionId, $currentPeriod - 1);
+		return $this->orderHandler->getOrderFromMagento('subscription',
+			$subscriptionId, $currentPeriod - 1);
 	}
 
 	/**
@@ -74,13 +75,13 @@ class Vindi_Subscription_Helper_Bill
 		foreach ($data['bill']['bill_items'] as $billItem) {
 			if ($billItem['product']['code'] == 'frete') {
 				$vindiData['shipping'] = $billItem;
+				continue;
 			}
-			elseif ($billItem['product']['code'] == 'taxa') {
+			if ($billItem['product']['code'] == 'taxa') {
 				$vindiData['taxes'][] = $billItem;
+				continue;
 			}
-			else {
-				$vindiData['products'][] = $billItem;
-			}
+			$vindiData['products'][] = $billItem;
 		}
 		return $vindiData;
 	}

--- a/app/code/community/Vindi/Subscription/Helper/Bill.php
+++ b/app/code/community/Vindi/Subscription/Helper/Bill.php
@@ -26,13 +26,14 @@ class Vindi_Subscription_Helper_Bill
 
 		$order = $this->orderHandler->createOrder($lastOrder, $vindiData);
 
-		// Remove os produtos inativos
-		$this->orderHandler->updateProductsList($order, $vindiData, $bill['charges']);
-
-		if (!$order) {
+		if (! $order) {
 			$this->logger->log('Impossível gerar novo pedido!', 4);
 			return false;
 		}
+
+		// Remove os produtos inativos
+		$this->orderHandler->updateProductsList($order, $vindiData, $bill['charges']);
+
 		return $this->orderHandler->renewalOrder($order, $vindiData);
 	}
 

--- a/app/code/community/Vindi/Subscription/Helper/Logger.php
+++ b/app/code/community/Vindi/Subscription/Helper/Logger.php
@@ -1,0 +1,27 @@
+<?php
+
+class Vindi_Subscription_Helper_Logger
+{
+	/**
+	 * Grava o histórico de Webhooks recebidos
+	 *
+	 * @param string   $message, int|null $level
+	 */
+	public function log($message, $level = null)
+	{
+		Mage::log($message, $level, 'vindi_webhooks.log');
+
+		switch ($level) {
+		case 4:
+			http_response_code(422);
+			return false;
+			break;
+		case 5:
+			return false;
+			break;
+		default:
+			return true;
+			break;
+		}
+	}
+}

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -123,7 +123,6 @@ class Vindi_Subscription_Helper_Order
 	{
 		$invoice = $order->prepareInvoice();
 		$invoice->setRequestedCaptureCase(Mage_Sales_Model_Order_Invoice::CAPTURE_OFFLINE);
-		$invoice->setBaseGrandTotal($invoice->getGrandTotal());
 		$invoice->register();
 
 		Mage::getModel('core/resource_transaction')
@@ -160,29 +159,6 @@ class Vindi_Subscription_Helper_Order
 			->getFirstItem();
 	}
 
-	/**
-	 * Sincroniza os itens da fatura Vindi com os itens do pedido Magento
-	 *
-	 * @param Mage_Sales_Model_Order $order, array $vindiData
-	 */
-	public function updateProductsList($order, $vindiData)
-	{
-		$codes = [];
-		foreach ($vindiData['products'] as $product) {
-			$codes[] = $product['product']['code'];
-		}
-
-		$itens = $order->getAllItems();
-		foreach ($itens as $item) {
-			if (! in_array($item->getSku(), $codes)) {
-				$item->delete();
-				$order->setTotalItemCount(count($itens) - 1);
-				$order->setSubtotal($order->getSubtotal() - $item->getPrice());
-				$order->save();
-			}
-		}
-	}
-
 	/*
 	 * Atualiza o pedido inserindo as informações refentes a renovação de assinatura Vindi
 	 * 
@@ -194,8 +170,6 @@ class Vindi_Subscription_Helper_Order
 	{
 		$order->setVindiSubscriptionId($vindiData['bill']['subscription']);
 		$order->setVindiSubscriptionPeriod($vindiData['bill']['cycle']);
-		$order->setBaseGrandTotal($vindiData['bill']['amount']);
-		$order->setGrandTotal($vindiData['bill']['amount']);
 		$order->save();
 
 		if (Mage::getStoreConfig('vindi_subscription/general/bankslip_link_in_order_comment')) {
@@ -270,23 +244,6 @@ class Vindi_Subscription_Helper_Order
 	}
 
 	/*
-	 * Carrega os dados e valores referentes as Taxas do pedido
-	 *
-	 * @param Mage_Sales_Model_Quote $quote, array $vindiData
-	 */
-	private function loadTaxes($quote, $vindiData)
-	{
-		if (isset(reset($vindiData['taxes'])['pricing_schema']['price'])
-			&& ! empty(reset($vindiData['taxes'])['pricing_schema']['price'])) {
-			$quote->getShippingAddress()->setTaxAmount(
-				reset($vindiData['taxes'])['pricing_schema']['price']);
-		}
-
-		$quote->collectTotals()
-			->save();
-	}
-
-	/*
 	 * Carrega os dados e valores referentes aos Produtos do pedido
 	 *
 	 * @param Mage_Sales_Model_Quote $quote, array $vindiData
@@ -348,9 +305,6 @@ class Vindi_Subscription_Helper_Order
 
 		// Add Product values
 		$this->loadProducts($quote, $vindiData);
-
-		// Add Tax values
-		$this->loadTaxes($quote, $vindiData);
 
 		$session = Mage::getSingleton('core/session');
 		$session->setData('vindi_is_reorder', true);

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -1,0 +1,385 @@
+<?php
+
+class Vindi_Subscription_Helper_Order
+{
+	protected $logger;
+
+	public function __construct() {
+		$this->logger = Mage::helper('vindi_subscription/logger');
+	}
+
+	/**
+	 * Altera o status de um pedido para Cancelado
+	 *
+	 * @param Mage_Sales_Model_Order $order, String $gatewayMessage
+	 *
+	 */
+	public function updateToRejected($order, $gatewayMessage)
+	{
+		$order->setState(Mage_Sales_Model_Order::STATE_CANCELED, true,
+			sprintf('Todas as tentativas de pagamento foram rejeitadas. Motivo: "%s".',
+			$gatewayMessage), true);
+
+		$order->save();
+	}
+
+	/**
+	 * Adiciona no pedido uma mensagem de falha no pagamento
+	 *
+	 * @param Mage_Sales_Model_Order $order, String $gatewayMessage
+	 *
+	 */
+	public function addRetryStatusMessage($order, $gatewayMessage)
+	{
+		$order->addStatusHistoryComment(sprintf(
+			'Tentativa de Pagamento rejeitada. Motivo: "%s". Uma nova tentativa será feita.',
+			$gatewayMessage));
+
+		$order->save();
+	}
+
+	/**
+	 * Consulta via API uma fatura vindi através do ID
+	 * Esse se faz necessário, pois os Webhooks de 'charge' não retornam os dados da fatura
+	 *
+	 * @param int $billId
+	 *
+	 * @return bool|Mage_Sales_Model_Order
+	 */
+	public function getOrderFromVindi($billId)
+	{
+		/** @var Vindi_Subscription_Helper_API $api */
+		$api = Mage::helper('vindi_subscription/api');
+		$bill = $api->getBill($billId);
+
+		if (! $bill) {
+			return false;
+		}
+		return $this->getOrder(compact('bill'));
+	}
+
+	/**
+	 * Valida a existência do pedido (fatura/assinatura) com os parâmetros informados
+	 *
+	 * @param array $data
+	 *
+	 * @return Mage_Sales_Model_Order|bool
+	 */
+	public function getOrder($data)
+	{
+		if (!isset($data['bill'])) {
+			return false;
+		}
+
+		$orderCode = filter_var($data['bill']['subscription']['id'], FILTER_SANITIZE_NUMBER_INT);
+		if (isset($data['bill']['subscription']['id']) && $orderCode) {
+			$order = $this->getSubscriptionOrder($orderCode, $data['bill']['period']['cycle']);
+			$orderType = 'assinatura';
+		}
+		else {
+			$orderCode = $data['bill']['id'];
+			$order = $this->getSingleOrder($orderCode);
+			$orderType = 'fatura';
+		}
+
+		if (!$order || !$order->getId()) {
+			$this->logger->log(sprintf('Nenhum pedido encontrado para a "%s": %d.', $orderType,
+				$orderCode));
+			return false;
+		}
+		return $order;
+	}
+
+	/**
+	 * Tenta criar um 'fatura' no Magento
+	 * Uma invoice registra o histórico de tentativas e pagamentos em um pedido
+	 *
+	 * @param Mage_Sales_Model_Order $order
+	 *
+	 * @return bool
+	 */
+	public function createInvoice($order)
+	{
+		$orderId = $order->getId();
+		if ($orderId && $order->canInvoice()) {
+			$this->logger->log('Gerando fatura para o pedido: ' . $orderId);
+			$this->updateToSuccess($order);
+			$this->logger->log('Fatura gerada com sucesso.');
+			return true;
+		}
+		elseif ($orderId) { 
+			$this->logger->log('Impossível gerar fatura para o pedido ' . $orderId, 4);
+		}
+		return false;
+	}
+
+	/**
+	 * Atualiza o status de uma 'fatura' no Magento para processando (pago)
+	 *
+	 * @param Mage_Sales_Model_Order $order
+	 */
+	public function updateToSuccess($order)
+	{
+		$invoice = $order->prepareInvoice();
+		$invoice->setRequestedCaptureCase(Mage_Sales_Model_Order_Invoice::CAPTURE_OFFLINE);
+		$invoice->setBaseGrandTotal($invoice->getGrandTotal());
+		$invoice->register();
+
+		Mage::getModel('core/resource_transaction')
+			->addObject($invoice)
+			->addObject($invoice->getOrder())
+			->save();
+		$invoice->sendEmail(true);
+		$order->setState(Mage_Sales_Model_Order::STATE_PROCESSING, true,
+			'O pagamento foi confirmado e o pedido está sendo processado.', true);
+		$order->save();
+	}
+
+	/**
+	 * Busca um pedido referente a uma assinatura Vindi
+	 *
+	 * @param int $subscriptionId, int $subscriptionPeriod
+	 *
+	 * @return Mage_Sales_Model_Order
+	 */
+	public function getSubscriptionOrder($subscriptionId, $subscriptionPeriod)
+	{
+		return Mage::getModel('sales/order')
+		    ->getCollection()
+			->addAttributeToSelect('*')
+			->addFieldToFilter('vindi_subscription_id', $subscriptionId)
+			->addFieldToFilter('vindi_subscription_period', $subscriptionPeriod)
+			->getFirstItem();
+	}
+
+	/**
+	 * Busca um pedido referente a uma fatura Vindi
+	 *
+	 * @param int $billId
+	 *
+	 * @return Mage_Sales_Model_Order
+	 */
+	private function getSingleOrder($billId)
+	{
+		return Mage::getModel('sales/order')
+		    ->getCollection()
+			->addAttributeToSelect('*')
+			->addFieldToFilter('vindi_bill_id', $billId)
+			->getFirstItem();
+	}
+
+	/**
+	 * Sincroniza os itens da fatura Vindi com os itens do pedido Magento
+	 *
+	 * @param Mage_Sales_Model_Order $order, array $vindiData
+	 */
+	public function updateProductsList($order, $vindiData)
+	{
+		$codes = [];
+		foreach ($vindiData['products'] as $product) {
+			$codes[] = $product['product']['code'];
+		}
+
+		$itens = $order->getAllItems();
+		foreach ($itens as $item) {
+			if (!in_array($item->getSku(), $codes)) {
+				$item->delete();
+				$order->setTotalItemCount(count($items) - 1);
+				$order->setSubtotal($order->getSubtotal() - $item->getPrice());
+				$order->save();
+			}
+		}
+	}
+
+	/*
+	 * Atualiza o pedido inserindo as informações refentes a renovação de assinatura Vindi
+	 * 
+	 * @param Mage_Sales_Model_Order $order, array $vindiData, array $charges
+	 *
+	 * @return bool
+	 */
+	public function renewalOrder($order, $vindiData, $charges)
+	{
+		$order->setVindiSubscriptionId($vindiData['bill']['subscription']);
+		$order->setVindiSubscriptionPeriod($vindiData['bill']['cycle']);
+		$order->setBaseGrandTotal($vindiData['bill']['amount']);
+		$order->setGrandTotal($vindiData['bill']['amount']);
+		$order->save();
+
+		if (Mage::getStoreConfig('vindi_subscription/general/bankslip_link_in_order_comment')) {
+			foreach ($charges as $charge) {
+				if ($charge['payment_method']['type'] == 'PaymentMethod::BankSlip') {
+					$order->addStatusHistoryComment(sprintf(
+						'<a target="_blank" href="%s">Clique aqui</a> para visualizar o boleto.',
+						$charge['print_url']
+					))->setIsVisibleOnFront(true);
+					$order->save();
+				}
+			}
+		}
+		$this->logger->log(sprintf('Novo pedido gerado: %s.', $order->getId()));
+		return true;
+	}
+
+	/*
+	 * Carrega os dados e valores referentes ao Frete do pedido
+	 *
+	 * @param Mage_Sales_Model_Quote $quote, array $vindiData, Mage_Sales_Model_Quote $shippingMethod 
+	 */
+	private function loadShipping($quote, $vindiData, $shippingMethod)
+	{
+		// Carrega todos os métodos de entrega
+		$activedShippingMethods = Mage::getSingleton('vindi_subscription/config_shippingmethod')
+			->getActivedShippingMethodsValues();
+
+		// Verifica se o método recebido está ativo
+		if (! in_array($shippingMethod, $activedShippingMethods)) {
+			$oldShippingMethod = $shippingMethod;
+			$shippingMethod = Mage::getStoreConfig(
+				'vindi_subscription/general/default_shipping_method');
+			$this->logger->log(sprintf(
+				"Erro ao utilizar o método de envio %s alterado para o método padrão %s.",
+				$oldShippingMethod, $shippingMethod));
+			unset($oldShippingMethod);
+		}
+
+		// Carrega os valores padrões do método de entrega
+		$quote->getShippingAddress()
+			->setShippingMethod($shippingMethod)
+			->setCollectShippingRates(true)
+			->collectShippingRates()
+			->collectTotals();
+
+		if (isset($vindiData['shipping']['pricing_schema']['price'])
+			&& !empty($vindiData['shipping']['pricing_schema']['price'])) {
+
+			// Seta o novo valor do frete
+			$billShippingPrice = $vindiData['shipping']['pricing_schema']['price'];
+
+			$quote->setPrice($billShippingPrice)
+				->setCost($billShippingPrice);
+
+			$address = $quote->getShippingAddress();
+			$address->setShippingAmount($billShippingPrice);
+			$address->setBaseShippingAmount($billShippingPrice);
+
+			$rates = $address->collectShippingRates()
+				->getGroupedAllShippingRates();
+
+			foreach ($rates as $carrier) {
+				foreach ($carrier as $rate) {
+					$rate->setPrice($billShippingPrice);
+					$rate->save();
+				}
+			}
+			$address->save();
+		}
+		$quote->save();
+	}
+
+	/*
+	 * Carrega os dados e valores referentes as Taxas do pedido
+	 *
+	 * @param Mage_Sales_Model_Quote $quote, array $vindiData
+	 */
+	private function loadTaxes($quote, $vindiData)
+	{
+		if (isset(reset($vindiData['taxes'])['pricing_schema']['price'])
+			&& ! empty(reset($vindiData['taxes'])['pricing_schema']['price'])) {
+			$quote->getShippingAddress()->setTaxAmount(
+				reset($vindiData['taxes'])['pricing_schema']['price']);
+		}
+
+		$quote->collectTotals()
+			->save();
+	}
+
+	/*
+	 * Carrega os dados e valores referentes aos Produtos do pedido
+	 *
+	 * @param Mage_Sales_Model_Quote $quote, array $vindiData
+	 */
+	private function loadProducts($quote, $vindiData)
+	{
+		foreach ($vindiData['products'] as $item) {
+			$magentoProduct = Mage::getModel('catalog/product')
+				->loadByAttribute('vindi_product_id', $item['product']['id']);
+
+			if (! $magentoProduct) {
+				$this->logger->log(sprintf('O produto com ID Vindi #%s não existe no Magento.',
+					$item['product']['id']), 5);
+			}
+			elseif (number_format($magentoProduct->getPrice(), 2)
+				!== number_format($item['pricing_schema']['price'], 2)) {
+
+				$this->logger->log(sprintf("Divergencia de valores na fatura #%s:  " . 
+					"produto %s: ID Magento #%s , ID Vindi #%s: " . 
+					"Valor Magento R$ %s , Valor Vindi R$ %s",
+					$vindiData['bill']['id'],
+					$magentoProduct->getName(),
+					$magentoProduct->getId(),
+					$item['product']['id'],
+					$magentoProduct->getPrice(),
+					$item['pricing_schema']['price']));
+
+				$quote->getItemByProduct($magentoProduct)
+					->setOriginalCustomPrice($item['pricing_schema']['price'])
+					->setCustomPrice($item['pricing_schema']['price'])
+					->save();
+			}
+		}
+		$quote->setTotalsCollectedFlag(false)
+			->collectTotals()
+			->save();
+	}
+
+	/**
+	 * Cria um novo pedido no Magento utilizando a função 're-order'
+	 *
+	 * @param Mage_Sales_Model_Order $oldOrder, array $vindiData
+	 *
+	 * @return Mage_Sales_Model_Order|bool
+	 */
+	public function createOrder($oldOrder, $vindiData)
+	{
+		$oldOrder->setReordered(true);
+
+		$model = Mage::getSingleton('adminhtml/sales_order_create');
+
+		/** @var Mage_Adminhtml_Model_Sales_Order_Create $order */
+		$order = $model->initFromOrder($oldOrder);
+
+		$quote = $order->getQuote();
+
+		// Add Shipping values
+		$this->loadShipping($quote, $vindiData, $oldOrder->getShippingMethod());
+
+		// Add Product values
+		$this->loadProducts($quote, $vindiData);
+
+		// Add Tax values
+		$this->loadTaxes($quote, $vindiData);
+
+		$session = Mage::getSingleton('core/session');
+		$session->setData('vindi_is_reorder', true);
+
+		try {
+			$order = $order->createOrder();
+		}
+		catch (Exception $e) {
+			$this->logger->log("Erro ao criar pedido!");
+
+			if ($e->getMessage()) {
+				$this->logger->log($e->getMessage(), 5);
+			}
+			else {
+				$messages = $order->getSession()->getMessages(true);
+				foreach ($messages->getItems() as $message) {
+					$this->logger->log($message->getText(), 5);
+				}
+			}
+			return false;
+		}
+		return $order;
+	}
+}

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -67,7 +67,7 @@ class Vindi_Subscription_Helper_Order
 	 */
 	public function getOrder($data)
 	{
-		if (!isset($data['bill'])) {
+		if (! isset($data['bill'])) {
 			return false;
 		}
 
@@ -78,12 +78,12 @@ class Vindi_Subscription_Helper_Order
 				$orderCode, $data['bill']['period']['cycle']);
 		}
 		else {
-			$orderCode = $data['bill']['id'];
+			$orderCode = filter_var($data['bill']['id'], FILTER_SANITIZE_NUMBER_INT);
 			$orderType = 'fatura';
 			$order = $this->getOrderFromMagento($orderType, $orderCode);
 		}
 
-		if (!$order || !$order->getId()) {
+		if (! $order || ! $order->getId()) {
 			$this->logger->log(sprintf('Nenhum pedido encontrado para a "%s": %d.', $orderType,
 				$orderCode));
 			return false;
@@ -174,7 +174,7 @@ class Vindi_Subscription_Helper_Order
 
 		$itens = $order->getAllItems();
 		foreach ($itens as $item) {
-			if (!in_array($item->getSku(), $codes)) {
+			if (! in_array($item->getSku(), $codes)) {
 				$item->delete();
 				$order->setTotalItemCount(count($itens) - 1);
 				$order->setSubtotal($order->getSubtotal() - $item->getPrice());
@@ -243,7 +243,7 @@ class Vindi_Subscription_Helper_Order
 			->collectTotals();
 
 		if (isset($vindiData['shipping']['pricing_schema']['price'])
-			&& !empty($vindiData['shipping']['pricing_schema']['price'])) {
+			&& ! empty($vindiData['shipping']['pricing_schema']['price'])) {
 
 			// Seta o novo valor do frete
 			$billShippingPrice = $vindiData['shipping']['pricing_schema']['price'];

--- a/app/code/community/Vindi/Subscription/Helper/Validator.php
+++ b/app/code/community/Vindi/Subscription/Helper/Validator.php
@@ -1,0 +1,95 @@
+<?php
+
+class Vindi_Subscription_Helper_Validator
+{
+	protected $logger;
+	protected $billHandler;
+	protected $orderHandler;
+
+	public function __construct() {
+		$this->logger       = Mage::helper('vindi_subscription/logger');
+		$this->billHandler  = Mage::helper('vindi_subscription/bill');
+		$this->orderHandler = Mage::helper('vindi_subscription/order');
+	}
+
+	/**
+	 * Valida estrutura do Webhook 'charge_rejected'
+	 *
+	 * @param array $data
+	 *
+	 * @return bool
+	 */
+	public function validateChargeWebhook($data)
+	{
+		$charge = $data['charge'];
+		$order = $this->orderHandler->getOrderFromVindi($charge['bill']['id']);
+		
+		if (! $order) {
+			$this->logger->log('Pedido não encontrado.', 4);
+			return false;
+		}
+
+		$gatewayMessage = $charge['last_transaction']['gateway_message'];
+
+		if (is_null($charge['next_attempt'])) {
+			$this->orderHandler->updateToRejected($order, $gatewayMessage);
+			$this->logger->log(sprintf(
+				'Todas as tentativas de pagamento do pedido %s foram rejeitadas. Motivo: "%s".',
+				$order->getId(), $gatewayMessage));
+		} else {
+			$this->orderHandler->addRetryStatusMessage($order, $gatewayMessage);
+			$this->logger->log(sprintf(
+				'Tentativa de pagamento do pedido %s foi rejeitada. Motivo: "%s".' .
+				' Uma nova tentativa será feita.', $order->getId(), $gatewayMessage));
+		}
+		return true;
+	}
+
+	/**
+	 * Valida estrutura do Webhook 'bill_created'
+	 *
+	 * @param array $data
+	 *
+	 * @return bool
+	 */
+	public function validateBillCreatedWebhook($data)
+	{
+		$bill = $data['bill'];
+
+		if (! $bill) {
+			$this->logger->log('Erro ao interpretar webhook "bill_created".', 5);
+			return false;
+		}
+
+		if (! isset($bill['subscription']) || is_null($bill['subscription'])) {
+			$this->logger->log(sprintf('Ignorando o evento "bill_created" para venda avulsa.'), 5);
+			return false;
+		}
+
+		if (isset($bill['period']) && ($bill['period']['cycle'] === 1)) {
+			$this->logger->log(sprintf(
+				'Ignorando o evento "bill_created" para o primeiro ciclo.'), 5);
+			return false;
+		}
+
+		$order = $this->orderHandler->getOrder($data);
+
+		if ($order) {
+			$this->logger->log(sprintf('Já existe o pedido %s para o evento "bill_created".',
+				$order->getId()), 5);
+			return false;
+		}
+
+		if (isset($bill['subscription']['id']) && ($bill['period']['cycle'])) {
+			$lastPeriodOrder = $this->billHandler->getLastPeriod($data);
+
+			if (! $lastPeriodOrder || ! $lastPeriodOrder->getId()) {
+				$this->logger->log('Pedido anterior não encontrado. Ignorando evento.', 4);
+				return false;
+			}
+			$this->billHandler->processBillCreated($data);
+		}
+
+		return true;
+	}
+}

--- a/app/code/community/Vindi/Subscription/Helper/Validator.php
+++ b/app/code/community/Vindi/Subscription/Helper/Validator.php
@@ -36,12 +36,13 @@ class Vindi_Subscription_Helper_Validator
 			$this->logger->log(sprintf(
 				'Todas as tentativas de pagamento do pedido %s foram rejeitadas. Motivo: "%s".',
 				$order->getId(), $gatewayMessage));
-		} else {
-			$this->orderHandler->addRetryStatusMessage($order, $gatewayMessage);
-			$this->logger->log(sprintf(
-				'Tentativa de pagamento do pedido %s foi rejeitada. Motivo: "%s".' .
-				' Uma nova tentativa será feita.', $order->getId(), $gatewayMessage));
+			return true;
 		}
+
+		$this->orderHandler->addRetryStatusMessage($order, $gatewayMessage);
+		$this->logger->log(sprintf(
+			'Tentativa de pagamento do pedido %s foi rejeitada. Motivo: "%s".' .
+			' Uma nova tentativa será feita.', $order->getId(), $gatewayMessage));
 		return true;
 	}
 
@@ -80,16 +81,14 @@ class Vindi_Subscription_Helper_Validator
 			return false;
 		}
 
-		if (isset($bill['subscription']['id']) && ($bill['period']['cycle'])) {
-			$lastPeriodOrder = $this->billHandler->getLastPeriod($data);
-
-			if (! $lastPeriodOrder || ! $lastPeriodOrder->getId()) {
-				$this->logger->log('Pedido anterior não encontrado. Ignorando evento.', 4);
-				return false;
-			}
+		if (isset($bill['subscription']['id'])
+			&& $bill['period']['cycle']
+			&& ($lastPeriodOrder = $this->billHandler->getLastPeriod($data))
+			&& $lastPeriodOrder->getId()) {
 			$this->billHandler->processBillCreated($data);
+			return true;
 		}
-
-		return true;
+		$this->logger->log('Pedido anterior não encontrado. Ignorando evento.', 4);
+		return false;
 	}
 }

--- a/app/code/community/Vindi/Subscription/Helper/WebhookHandler.php
+++ b/app/code/community/Vindi/Subscription/Helper/WebhookHandler.php
@@ -2,497 +2,58 @@
 
 class Vindi_Subscription_Helper_WebhookHandler extends Mage_Core_Helper_Abstract
 {
-    /**
-     * @param string   $message
-     * @param int|null $level
-     */
-    public function log($message, $level = null)
-    {
-        Mage::log($message, $level, 'vindi_webhooks.log');
 
-        switch ($level) {
-            case 4:
-                http_response_code(422);
-                return false;
-                break;
-            case 5:
-                return false;
-                break;
-            default:
-                return true;
-                break;
-        }
-
-    }
-
-    /**
-     * Handle incoming webhook.
-     *
-     * @param string $body
-     *
-     * @return bool
-     */
-    public function handle($body)
-    {
-        try {
-            $jsonBody = json_decode($body, true);
-
-            if (! $jsonBody || ! isset($jsonBody['event'])) {
-                Mage::throwException('Evento do Webhook não encontrado!');
-            }
-
-            $type = $jsonBody['event']['type'];
-            $data = $jsonBody['event']['data'];
-        } catch (Exception $e) {
-            $this->log(sprintf('Falha ao interpretar JSON do webhook: %s', $e->getMessage()), 5);
-            return false;
-        }
-
-        switch ($type) {
-            // the webhook is being called before Order is actually placed.
-            // I'm sorry for this, not going to use queues for now, so the solution is to use sleep().
-
-            case 'test':
-                $this->log('Evento de teste do webhook.');
-                return false;
-            case 'bill_created':
-                return $this->billCreated($data);
-            case 'bill_paid':
-                return $this->billPaid($data);
-            case 'charge_rejected':
-                return $this->chargeRejected($data);
-            default:
-                $this->log(sprintf('Evento do webhook ignorado pelo plugin: "%s".', $type), 5);
-        }
-    }
-
-    /**
-     * Handle 'bill_created' event.
-     * The bill can be related to a subscription or a single payment.
-     *
-     * @param array $data
-     *
-     * @return bool
-     */
-    public function billCreated($data)
-    {
-        if (! ($bill = $data['bill'])) {
-            $this->log('Erro ao interpretar webhook "bill_created".', 5);
-
-            return false;
-        }
-
-        if (! isset($bill['subscription']) || is_null($bill['subscription'])) {
-            $this->log(sprintf('Ignorando o evento "bill_created" para venda avulsa.'), 5);
-
-            return false;
-        }
-
-        $period = intval($bill['period']['cycle']);
-
-        if (isset($bill['period']) && ($period === 1)) {
-            $this->log(sprintf('Ignorando o evento "bill_created" para o primeiro ciclo.'), 5);
-
-            return false;
-        }
-
-        if (($order = $this->getOrder($data))) {
-            $this->log(sprintf('Já existe o pedido %s para o evento "bill_created".', $order->getId()), 5);
-
-            return false;
-        }
-
-        $subscriptionId = $bill['subscription']['id'];
-        $lastPeriodOrder = $this->getOrderForPeriod($subscriptionId, $period - 1);
-
-        if (! $lastPeriodOrder || ! $lastPeriodOrder->getId()) {
-            $this->log('Pedido anterior não encontrado. Ignorando evento.', 4);
-
-            return false;
-        }
-
-        $vindiData = [
-                    'bill'     => [
-                                    'id'    => $data['bill']['id'],
-                                    'amount' => $data['bill']['amount']
-                                ],
-                    'products' => [],
-                    'shipping' => [],
-                    'taxes'    => [],
-                ];
-        foreach ($data['bill']['bill_items'] as $billItem) {
-            if ($billItem['product']['code'] == 'frete') {
-                $vindiData['shipping'] = $billItem;
-            } elseif ($billItem['product']['code'] == 'taxa') {
-                $vindiData['taxes'][] = $billItem;
-            } else {
-                $vindiData['products'][] = $billItem;
-            }
-        }
-
-        $order = $this->createOrder($lastPeriodOrder, $vindiData);
-
-        // remove inactive products
-        $this->updateProductsList($order, $vindiData);
-
-        if (! $order) {
-            $this->log('Impossível gerar novo pedido!', 4);
-
-            return false;
-        }
-
-        $this->log(sprintf('Novo pedido gerado: %s.', $order->getId()));
-
-        $order->setVindiSubscriptionId($subscriptionId);
-        $order->setVindiSubscriptionPeriod($period);
-        $order->setBaseGrandTotal($vindiData['bill']['amount']);
-        $order->setGrandTotal($vindiData['bill']['amount']);
-        $order->save();
-
-        if(Mage::getStoreConfig('vindi_subscription/general/bankslip_link_in_order_comment'))
-        {
-            foreach ($data['bill']['charges'] as $charge)
-            {
-                if ($charge['payment_method']['type'] == 'PaymentMethod::BankSlip')
-                {
-                    $order->addStatusHistoryComment(sprintf(
-                        '<a target="_blank" href="%s">Clique aqui</a> para visualizar o boleto.',
-                        $charge['print_url']
-                    ))
-                    ->setIsVisibleOnFront(true);
-                    $order->save();
-                }
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Handle 'bill_paid' event.
-     * The bill can be related to a subscription or a single payment.
-     *
-     * @param array $data
-     *
-     * @return bool
-     */
-    public function billPaid($data)
-    {
-        if (! ($order = $this->getOrder($data))) {
-            $this->log(sprintf('Ainda não existe um pedido para ciclo %s da assinatura: %d.',
-                $data['bill']['period']['cycle'],
-                $data['bill']['subscription']['id']),
-                4
-            );
-
-            return false;
-        }
-
-        return $this->createInvoice($order);
-    }
-
-    /**
-     * @param array $data
-     *
-     * @return bool
-     * @throws \Exception
-     */
-    public function chargeRejected($data)
-    {
-        $charge = $data['charge'];
-
-        if (! ($order = $this->getOrderFromBill($charge['bill']['id']))) {
-            $this->log('Pedido não encontrado.', 4);
-
-            return false;
-        }
-
-        $gatewayMessage = $charge['last_transaction']['gateway_message'];
-        $isLastAttempt = is_null($charge['next_attempt']);
-
-        if ($isLastAttempt) {
-            $order->setState(Mage_Sales_Model_Order::STATE_CANCELED, true, sprintf(
-                'Todas as tentativas de pagamento foram rejeitadas. Motivo: "%s".',
-                $gatewayMessage
-            ), true);
-            $this->log(sprintf(
-                'Todas as tentativas de pagamento do pedido %s foram rejeitadas. Motivo: "%s".',
-                $order->getId(),
-                $gatewayMessage
-            ));
-        } else {
-            $order->addStatusHistoryComment(sprintf(
-                'Tentativa de Pagamento rejeitada. Motivo: "%s". Uma nova tentativa será feita.',
-                $gatewayMessage
-            ));
-            $this->log(sprintf(
-                'Tentativa de pagamento do pedido %s foi rejeitada. Motivo: "%s". Uma nova tentativa será feita.',
-                $order->getId(),
-                $gatewayMessage
-            ));
-        }
-
-        $order->save();
-
-        return true;
-    }
-
-    /**
-     * @param Mage_Sales_Model_Order $order
-     *
-     * @return bool
-     */
-    public function createInvoice($order)
-    {
-        if (! $order->getId()) {
-            return false;
-        }
-
-        $this->log(sprintf('Gerando fatura para o pedido: %s.', $order->getId()));
-
-        $order->setState(Mage_Sales_Model_Order::STATE_PROCESSING, true,
-            'O pagamento foi confirmado e o pedido está sendo processado.', true);
-
-        if (! $order->canInvoice()) {
-            $this->log(sprintf('Impossível gerar fatura para o pedido %s.', $order->getId()), 4);
-
-            // TODO define how to handle this
-
-            return false;
-        }
-        $invoice = $order->prepareInvoice();
-        $invoice->setRequestedCaptureCase(Mage_Sales_Model_Order_Invoice::CAPTURE_OFFLINE);
-        $invoice->register();
-        Mage::getModel('core/resource_transaction')->addObject($invoice)->addObject($invoice->getOrder())->save();
-        $invoice->sendEmail(true);
-        $this->log('Fatura gerada com sucesso.');
-
-        return true;
-    }
-
-    /**
-     * @param array $data
-     *
-     * @return Mage_Sales_Model_Order|bool
-     */
-    private function getOrder($data)
-    {
-        if (! isset($data['bill'])) {
-            return false;
-        }
-
-        if (isset($data['bill']['subscription']) && ($subscription = $data['bill']['subscription'])
-            && ($subscriptionId = filter_var($subscription['id'], FILTER_SANITIZE_NUMBER_INT))
-        ) {
-            $order = $this->getOrderForPeriod($subscriptionId, $data['bill']['period']['cycle']);
-
-            if (! $order || ! $order->getId()) {
-                $this->log(sprintf('Nenhum pedido encontrado para a assinatura: %d.', $subscriptionId));
-
-                return false;
-            }
-
-            return $order;
-        } else {
-            $order = $this->getSingleOrder($data['bill']['id']);
-
-            if (! $order || ! $order->getId()) {
-                $this->log(sprintf('Nenhum pedido encontrado para a fatura: %d.', $data['bill']['id']));
-
-                return false;
-            }
-
-            return $order;
-        }
-    }
-
-    /**
-     * @param int $billId
-     *
-     * @return bool|\Mage_Sales_Model_Order
-     */
-    private function getOrderFromBill($billId)
-    {
-        /** @var Vindi_Subscription_Helper_API $api */
-        $api = Mage::helper('vindi_subscription/api');
-
-        if (! $bill = $api->getBill($billId)) {
-            return false;
-        }
-
-        return $this->getOrder(compact('bill'));
-    }
-
-    /**
-     * @param int $subscriptionId
-     * @param int $subscriptionPeriod
-     *
-     * @return Mage_Sales_Model_Order
-     */
-    private function getOrderForPeriod($subscriptionId, $subscriptionPeriod)
-    {
-        return Mage::getModel('sales/order')->getCollection()
-            ->addAttributeToSelect('*')
-            ->addFieldToFilter('vindi_subscription_id', $subscriptionId)
-            ->addFieldToFilter('vindi_subscription_period', $subscriptionPeriod)
-            ->getFirstItem();
-    }
-
-    /**
-     * @param int $billId
-     *
-     * @return Mage_Sales_Model_Order
-     */
-    private function getSingleOrder($billId)
-    {
-        return Mage::getModel('sales/order')->getCollection()
-            ->addAttributeToSelect('*')
-            ->addFieldToFilter('vindi_bill_id', $billId)
-            ->getFirstItem();
-    }
-
-    private function updateProductsList($order, $vindiData)
-    {
-        $codes = [];
-        foreach ($vindiData['products'] as $product) {
-            $codes[] = $product['product']['code'];
-        }
-
-        $itens = $order->getAllItems();
-        foreach ($itens as $item) {
-            if (!in_array($item->getSku(), $codes)) {
-                $item->delete();
-                $order->setTotalItemCount(count($items) - 1);
-                $order->setSubtotal($order->getSubtotal() - $item->getPrice());
-                $order->save();
-            }
-        }
-    }
-
-    /**
-     * Create a new order from an old one using reorder functionality.
-     *
-     * @param Mage_Sales_Model_Order $oldOrder
-     *
-     * @return Mage_Sales_Model_Order;
-     */
-    private function createOrder($oldOrder, $vindiData)
-    {
-        $oldOrder->setReordered(true);
-
-        $model = Mage::getSingleton('adminhtml/sales_order_create');
-
-        /** @var Mage_Adminhtml_Model_Sales_Order_Create $order */
-        $order = $model->initFromOrder($oldOrder);
-
-        $quote = $order->getQuote();
-
-        // get shipping method
-        $shippingMethod = $oldOrder->getShippingMethod();
-        $activedShippingMethods = Mage::getSingleton('vindi_subscription/config_shippingmethod')->getActivedShippingMethodsValues();
-
-        // verify if current shipping method is active
-        if(!in_array($shippingMethod, $activedShippingMethods)){
-            $oldShippingMethod = $shippingMethod;
-            $shippingMethod = Mage::getStoreConfig('vindi_subscription/general/default_shipping_method');
-            $this->log(sprintf("Erro ao utilizar o método de envio %s alterado para o método padrão %s.",
-                        $oldShippingMethod,
-                        $shippingMethod
-                    ));
-            unset($oldShippingMethod);
-        }
-
-        // quote shipping method
-        $quote->getShippingAddress()
-            ->setShippingMethod($shippingMethod)
-            ->setCollectShippingRates(true)
-            ->collectShippingRates()
-            ->collectTotals();
-
-        if(isset($vindiData['shipping']['pricing_schema']['price']) && !empty($vindiData['shipping']['pricing_schema']['price']))
-        {
-            // set shipping price
-            $billShippingPrice = $vindiData['shipping']['pricing_schema']['price'];
-
-            $quote->setPrice($billShippingPrice)
-                ->setCost($billShippingPrice);
-
-            $address = $quote->getShippingAddress();
-            $address->setShippingAmount($billShippingPrice);
-            $address->setBaseShippingAmount($billShippingPrice);
-
-            $rates = $address->collectShippingRates()
-                            ->getGroupedAllShippingRates();
-            foreach ($rates as $carrier) {
-                foreach ($carrier as $rate) {
-                    $rate->setPrice($billShippingPrice);
-                    $rate->save();
-                }
-            }
-            $address->save();
-        }
-
-        $quote->save();
-
-        foreach ($vindiData['products'] as $item) {
-            $magentoProduct = Mage::getModel('catalog/product')->loadByAttribute('vindi_product_id', $item['product']['id']);
-            if(!$magentoProduct)
-            {
-                $this->log(sprintf('O produto com ID Vindi #%s não existe no Magento.', $item['product']['id']), 5);
-            }else{
-                if(number_format($magentoProduct->getPrice(), 2) !== number_format($item['pricing_schema']['price'], 2)){
-                    $this->log(sprintf("Divergencia de valores na fatura #%s: produto %s: ID Magento #%s , ID Vindi #%s: Valor Magento R$ %s , Valor Vindi R$ %s",
-                                $vindiData['bill']['id'],
-                                $magentoProduct->getName(),
-                                $magentoProduct->getId(),
-                                $item['product']['id'],
-                                $magentoProduct->getPrice(),
-                                $item['pricing_schema']['price'])
-                            );
-
-                    $quote->getItemByProduct($magentoProduct)
-                        // ->setPrice($item['pricing_schema']['price'])
-                        // ->setCost($item['pricing_schema']['price'])
-                        ->setOriginalCustomPrice($item['pricing_schema']['price'])
-                        ->setCustomPrice($item['pricing_schema']['price'])
-                        ->save();
-
-                }
-            }
-        }
-
-        $quote->setTotalsCollectedFlag(false)
-            ->collectTotals()
-            ->save();
-
-        if (isset(reset($vindiData['taxes'])['pricing_schema']['price']) && !empty(reset($vindiData['taxes'])['pricing_schema']['price'])) {
-                $quote->getShippingAddress()->setTaxAmount(reset($vindiData['taxes'])['pricing_schema']['price']);
-        }
-
-        $quote->collectTotals()
-            ->save();
-
-        $session = Mage::getSingleton('core/session');
-        $session->setData('vindi_is_reorder', true);
-
-        try {
-            $order = $order->createOrder();
-        } catch (Exception $e) {
-            $this->log("Erro ao criar pedido!");
-
-            if($e->getMessage()){
-                $this->log($e->getMessage(), 5);
-            }else{
-                $messages = $order->getSession()->getMessages(true);
-                foreach($messages->getItems() as $message)
-                {
-                   $this->log($message->getText(), 5);
-                }
-            }
-
-            return false;
-        }
-
-        return $order;
-    }
+	protected $logger;
+	protected $billHandler;
+	protected $orderHandler;
+	protected $validator;
+
+	public function __construct() {
+		$this->logger       = Mage::helper('vindi_subscription/logger');
+		$this->billHandler  = Mage::helper('vindi_subscription/bill');
+		$this->orderHandler = Mage::helper('vindi_subscription/order');
+		$this->validator    = Mage::helper('vindi_subscription/validator');
+	}
+
+	/**
+	 * Filtra os Webhooks recebidos
+	 *
+	 * @param string $body
+	 *
+	 * @return bool
+	 */
+	public function handle($body)
+	{
+		try {
+			$jsonBody = json_decode($body, true);
+
+			if (! $jsonBody || ! isset($jsonBody['event'])) {
+				Mage::throwException('Evento do Webhook não encontrado!');
+			}
+
+			$type = $jsonBody['event']['type'];
+			$data = $jsonBody['event']['data'];
+		} catch (Exception $e) {
+			$this->logger->log('Falha ao interpretar JSON do webhook: ' . $e->getMessage(), 5);
+			return false;
+		}
+
+		switch ($type) {
+			// O Webhook pode ser recebido antes que o pedido seja criado.
+			// Para contornar é possível utilizar o sleep() ou criar filas.
+
+		case 'test':
+			$this->logger->log('Evento de teste do webhook.');
+			return false;
+		case 'bill_created':
+			return $this->validator->validateBillCreatedWebhook($data);
+		case 'bill_paid':
+			return $this->billHandler->processBillPaid($data);
+		case 'charge_rejected':
+			return $this->validator->validateChargeWebhook($data);
+		default:
+			$this->logger->log('Evento do webhook ignorado pelo plugin: ' . $type);
+			return true;
+		}
+	}
 }

--- a/app/code/community/Vindi/Subscription/Helper/WebhookHandler.php
+++ b/app/code/community/Vindi/Subscription/Helper/WebhookHandler.php
@@ -353,11 +353,14 @@ class Vindi_Subscription_Helper_WebhookHandler extends Mage_Core_Helper_Abstract
 
     private function updateProductsList($order, $vindiData)
     {
+        $codes = [];
+        foreach ($vindiData['products'] as $product) {
+            $codes[] = $product['product']['code'];
+        }
+
         $itens = $order->getAllItems();
         foreach ($itens as $item) {
-            // $item->getSku();
-            // $vindiData['products'][0]['product']['code'];
-            if ($item->getSku() == 'pav') {
+            if (!in_array($item->getSku(), $codes)) {
                 $item->delete();
                 $order->setTotalItemCount(count($items) - 1);
                 $order->setSubtotal($order->getSubtotal() - $item->getPrice());

--- a/app/code/community/Vindi/Subscription/Helper/WebhookHandler.php
+++ b/app/code/community/Vindi/Subscription/Helper/WebhookHandler.php
@@ -132,6 +132,9 @@ class Vindi_Subscription_Helper_WebhookHandler extends Mage_Core_Helper_Abstract
 
         $order = $this->createOrder($lastPeriodOrder, $vindiData);
 
+        // remove inactive products
+        $this->updateProductsList($order, $vindiData);
+
         if (! $order) {
             $this->log('Impossível gerar novo pedido!', 4);
 
@@ -142,6 +145,7 @@ class Vindi_Subscription_Helper_WebhookHandler extends Mage_Core_Helper_Abstract
 
         $order->setVindiSubscriptionId($subscriptionId);
         $order->setVindiSubscriptionPeriod($period);
+        $order->setBaseGrandTotal($vindiData['bill']['amount']);
         $order->setGrandTotal($vindiData['bill']['amount']);
         $order->save();
 
@@ -345,6 +349,21 @@ class Vindi_Subscription_Helper_WebhookHandler extends Mage_Core_Helper_Abstract
             ->addAttributeToSelect('*')
             ->addFieldToFilter('vindi_bill_id', $billId)
             ->getFirstItem();
+    }
+
+    private function updateProductsList($order, $vindiData)
+    {
+        $itens = $order->getAllItems();
+        foreach ($itens as $item) {
+            // $item->getSku();
+            // $vindiData['products'][0]['product']['code'];
+            if ($item->getSku() == 'pav') {
+                $item->delete();
+                $order->setTotalItemCount(count($items) - 1);
+                $order->setSubtotal($order->getSubtotal() - $item->getPrice());
+                $order->save();
+            }
+        }
     }
 
     /**

--- a/app/code/community/Vindi/Subscription/controllers/WebhookController.php
+++ b/app/code/community/Vindi/Subscription/controllers/WebhookController.php
@@ -2,40 +2,41 @@
 
 class Vindi_Subscription_WebhookController extends Mage_Core_Controller_Front_Action
 {
-    /**
-     * The route that webhooks will use.
-     */
-    public function indexAction()
-    {
-        /** @var Vindi_Subscription_Helper_WebhookHandler $handler */
-        $handler = Mage::helper('vindi_subscription/webhookHandler');
+	/**
+	 * Seta a rota dos  Webhooks
+	 */
+	public function indexAction()
+	{
+		/** @var Vindi_Subscription_Helper_WebhookHandler $handler */
+		$handler = Mage::helper('vindi_subscription/webhookHandler');
+		$logger = Mage::helper('vindi_subscription/logger');
 
-        if (! $this->validateRequest()) {
-            $ip = Mage::helper('core/http')->getRemoteAddr();
+		if (! $this->validateRequest()) {
+			$ip = Mage::helper('core/http')->getRemoteAddr();
 
-            $handler->log(sprintf('Invalid webhook attempt from IP %s', $ip), Zend_Log::WARN);
-            $this->norouteAction();
+			$logger->log(sprintf('Invalid webhook attempt from IP %s', $ip), Zend_Log::WARN);
+			$this->norouteAction();
 
-            return false;
-        }
+			return false;
+		}
 
-        $body = file_get_contents('php://input');
-        $handler->log(sprintf("Novo evento dos webhooks!\n%s", $body));
+		$body = file_get_contents('php://input');
+		$logger->log(sprintf("Novo evento dos webhooks!\n%s", $body));
 
-        return $handler->handle($body);
-    }
+		return $handler->handle($body);
+	}
 
-    /**
-     * Validate the webhook for security reasons.
-     *
-     * @return bool
-     */
-    private function validateRequest()
-    {
-        $systemKey = Mage::helper('vindi_subscription')->getHashKey();
-        $requestKey = $this->getRequest()->getParam('key');
+	/**
+	 * Valida o token do Webhook por questões de segurança
+	 *
+	 * @return bool
+	 */
+	private function validateRequest()
+	{
+		$systemKey = Mage::helper('vindi_subscription')->getHashKey();
+		$requestKey = $this->getRequest()->getParam('key');
 
-        return $systemKey === $requestKey;
-    }
+		return $systemKey === $requestKey;
+	}
 }
 


### PR DESCRIPTION
## Motivação
- O código do Magento está com alguns problemas de design, dificuldando qualquer alteração, seja para correção de bugs ou para adição de novas funcionalidades.
- Aparentemente os Webhooks não estão atuando da forma que deveriam.

## Solução Proposta
#### Refatoração da classe que lida com os webhooks da Vindi.
- [x] Separar as classes por responsabilidade
#### Validar o funcionamento dos Webhooks:
- [x] **bill_created**
O pedido deve ser criado no Magento com os valores atualizados de acordo com a assinatura na Vindi
### 
- [x] **bill_paid**
O pedido deve ser atualizado para o status '_processing_', e os valores de pagamento devem ser síncronos com os visualizados na Vindi.
### 
- [x] **charge_rejected**
O pedido deve receber a mensagem de falha na tentativa de cobrança;
Caso seja a última tentativa, o pedido deve receber o status '_cancelled_'