### PR TITLE
Corrige sincronização de fatura e pedido

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [1.4.0 - 29/01/2019](https://github.com/vindi/vindi-magento/releases/tag/1.4.0)
+
+### Corrigido
+- Corrige sincronização de produtos na assinatura Vindi
+- Corrige preço do pedido que não refletia o preço da fatura
+
 ## [1.3.4 - 11/01/2019](https://github.com/vindi/vindi-magento/releases/tag/1.3.4)
 
 ### Ajustado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 - Corrige sincronização de produtos na assinatura Vindi
 - Corrige preço do pedido que não refletia o preço da fatura
 
+
 ## [1.3.4 - 11/01/2019](https://github.com/vindi/vindi-magento/releases/tag/1.3.4)
 
 ### Ajustado
 - Ajusta a função getDebitCardRedirectUrl para pegar o redirect_url em vez de authorization_url
+
 
 ## [1.3.3 - 27/12/2018](https://github.com/vindi/vindi-magento/releases/tag/1.3.3)
 

--- a/app/code/community/Vindi/Subscription/Helper/Bill.php
+++ b/app/code/community/Vindi/Subscription/Helper/Bill.php
@@ -30,6 +30,10 @@ class Vindi_Subscription_Helper_Bill
 			$this->logger->log('Impossível gerar novo pedido!', 4);
 			return false;
 		}
+
+		// Remove os produtos inativos
+		$this->orderHandler->updateProductsList($order, $vindiData, $bill['charges']);
+
 		return $this->orderHandler->renewalOrder($order, $vindiData);
 	}
 
@@ -60,17 +64,22 @@ class Vindi_Subscription_Helper_Bill
 		$vindiData = [
 			'bill'     => [
 				'id'           => $data['bill']['id'],
-				'amount'       => $data['bill']['amout'],
+				'amount'       => $data['bill']['amount'],
 				'subscription' => $data['bill']['subscription']['id'],
 				'cycle'        => $data['bill']['period']['cycle']
 			],
 			'products' => [],
 			'shipping' => [],
+			'taxes'    => [],
 		];
 
 		foreach ($data['bill']['bill_items'] as $billItem) {
 			if ($billItem['product']['code'] == 'frete') {
 				$vindiData['shipping'] = $billItem;
+				continue;
+			}
+			if ($billItem['product']['code'] == 'taxa') {
+				$vindiData['taxes'][] = $billItem;
 				continue;
 			}
 			$vindiData['products'][] = $billItem;

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -123,6 +123,7 @@ class Vindi_Subscription_Helper_Order
 	{
 		$invoice = $order->prepareInvoice();
 		$invoice->setRequestedCaptureCase(Mage_Sales_Model_Order_Invoice::CAPTURE_OFFLINE);
+		$invoice->setBaseGrandTotal($invoice->getGrandTotal());
 		$invoice->register();
 
 		Mage::getModel('core/resource_transaction')
@@ -159,6 +160,29 @@ class Vindi_Subscription_Helper_Order
 			->getFirstItem();
 	}
 
+	/**
+	 * Sincroniza os itens da fatura Vindi com os itens do pedido Magento
+	 *
+	 * @param Mage_Sales_Model_Order $order, array $vindiData
+	 */
+	public function updateProductsList($order, $vindiData)
+	{
+		$codes = [];
+		foreach ($vindiData['products'] as $product) {
+			$codes[] = $product['product']['code'];
+		}
+
+		$itens = $order->getAllItems();
+		foreach ($itens as $item) {
+			if (! in_array($item->getSku(), $codes)) {
+				$item->delete();
+				$order->setTotalItemCount(count($itens) - 1);
+				$order->setSubtotal($order->getSubtotal() - $item->getPrice());
+				$order->save();
+			}
+		}
+	}
+
 	/*
 	 * Atualiza o pedido inserindo as informações refentes a renovação de assinatura Vindi
 	 * 
@@ -170,6 +194,8 @@ class Vindi_Subscription_Helper_Order
 	{
 		$order->setVindiSubscriptionId($vindiData['bill']['subscription']);
 		$order->setVindiSubscriptionPeriod($vindiData['bill']['cycle']);
+		$order->setBaseGrandTotal($vindiData['bill']['amount']);
+		$order->setGrandTotal($vindiData['bill']['amount']);
 		$order->save();
 
 		if (Mage::getStoreConfig('vindi_subscription/general/bankslip_link_in_order_comment')) {
@@ -244,6 +270,23 @@ class Vindi_Subscription_Helper_Order
 	}
 
 	/*
+	 * Carrega os dados e valores referentes as Taxas do pedido
+	 *
+	 * @param Mage_Sales_Model_Quote $quote, array $vindiData
+	 */
+	private function loadTaxes($quote, $vindiData)
+	{
+		if (isset(reset($vindiData['taxes'])['pricing_schema']['price'])
+			&& ! empty(reset($vindiData['taxes'])['pricing_schema']['price'])) {
+			$quote->getShippingAddress()->setTaxAmount(
+				reset($vindiData['taxes'])['pricing_schema']['price']);
+		}
+
+		$quote->collectTotals()
+			->save();
+	}
+
+	/*
 	 * Carrega os dados e valores referentes aos Produtos do pedido
 	 *
 	 * @param Mage_Sales_Model_Quote $quote, array $vindiData
@@ -305,6 +348,9 @@ class Vindi_Subscription_Helper_Order
 
 		// Add Product values
 		$this->loadProducts($quote, $vindiData);
+
+		// Add Tax values
+		$this->loadTaxes($quote, $vindiData);
 
 		$session = Mage::getSingleton('core/session');
 		$session->setData('vindi_is_reorder', true);

--- a/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.3.4</version>
+            <version>1.4.0</version>
         </Vindi_Subscription>
     </modules>
     <global>


### PR DESCRIPTION
Issue: [#1825](https://github.com/vindi/recurrent/issues/1825) e [#1823](https://github.com/vindi/recurrent/issues/1823)

## Motivação e Solução proposta
Ao realizar uma alteração na assinatura/ fatura via plataforma Vindi, os dados alterados não são refletidos no módulo Magento.

## Solução Proposta
- Validar o valor do produto Vindi obtido no webhook de Fatura criada (bill_created) e atualizar o Magento com os mesmos.
- Validar os produtos que expiraram ou foram removidos da assinatura na Vindi, para que não sejam exibidos no pedido do Magento.