### PR TITLE
Ajusta mensagem do método de pagamento Boleto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [1.4.1 - 11/02/2019](https://github.com/vindi/vindi-magento/releases/tag/1.4.1)
+
+### Corrigido
+- Corrige mensagem no checkout para exibição do boleto bancário
+
+
 ## [1.4.0 - 29/01/2019](https://github.com/vindi/vindi-magento/releases/tag/1.4.0)
 
 ### Corrigido

--- a/app/code/community/Vindi/Subscription/Block/Form/BankSlip.php
+++ b/app/code/community/Vindi/Subscription/Block/Form/BankSlip.php
@@ -10,31 +10,4 @@ class Vindi_Subscription_Block_Form_BankSlip extends Mage_Payment_Block_Form
         parent::_construct();
         $this->setTemplate('vindi_subscription/payment/form/bankslip.phtml');
     }
-    /**
-    * @return string
-    */
-    protected function getQuoteType()
-    {
-    	$quote = Mage::getSingleton('checkout/session')->getQuote();
-
-    	foreach ($quote->getAllVisibleItems() as $item) {
-            if (($product = $item->getProduct()) && ($product->getTypeId() === 'subscription')) {
-                return 'subscription';
-            }
-        }
-
-        return 'bill';
-    }
-    /**
-    * @return string
-    */
-    public function setMessageBankSlip()
-    {
-        $quote = Mage::getSingleton('checkout/session')->getQuote();
-
-    	if('subscription' == $this->getQuoteType($quote))
-    		return 'enviado mensalmente';
-
-    	return 'enviado';
-    }
 }

--- a/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.4.0</version>
+            <version>1.4.1</version>
         </Vindi_Subscription>
     </modules>
     <global>

--- a/app/design/adminhtml/base/default/template/vindi_subscription/payment/form/bankslip.phtml
+++ b/app/design/adminhtml/base/default/template/vindi_subscription/payment/form/bankslip.phtml
@@ -1,6 +1,6 @@
 <?php $_code = $this->getMethodCode() ?>
 <div id="payment_form_<?php echo $_code ?>" style="display:none;">
     <div class="block-payment-bankslip">
-        Um Boleto Bancário será enviado mensalmente para o seu endereço de e-mail.
+        O Boleto Bancário será enviado para o seu e-mail.
     </div>
 </div>

--- a/app/design/adminhtml/base/default/template/vindi_subscription/payment/form/bankslip.phtml
+++ b/app/design/adminhtml/base/default/template/vindi_subscription/payment/form/bankslip.phtml
@@ -1,6 +1,6 @@
 <?php $_code = $this->getMethodCode() ?>
 <div id="payment_form_<?php echo $_code ?>" style="display:none;">
     <div class="block-payment-bankslip">
-        O Boleto Bancário será enviado para o seu e-mail.
+        O boleto bancário será enviado para o seu e-mail.
     </div>
 </div>

--- a/app/design/frontend/base/default/template/vindi_subscription/payment/form/bankslip.phtml
+++ b/app/design/frontend/base/default/template/vindi_subscription/payment/form/bankslip.phtml
@@ -4,6 +4,6 @@
 
 <div id="payment_form_<?php echo $_code ?>" style="display:none;">
     <div class="block-payment-bankslip">
-	      O boleto bancário será enviado para o seu e-mail.
+	    O boleto bancário será enviado para o seu e-mail.
     </div>
 </div>

--- a/app/design/frontend/base/default/template/vindi_subscription/payment/form/bankslip.phtml
+++ b/app/design/frontend/base/default/template/vindi_subscription/payment/form/bankslip.phtml
@@ -1,10 +1,9 @@
 <?php 
 	$_code = $this->getMethodCode();
-	$text = $this->setMessageBankSlip();
 ?>
 
 <div id="payment_form_<?php echo $_code ?>" style="display:none;">
     <div class="block-payment-bankslip">
-	Um boleto bancário será <?=$text?> para o seu endereço de e-mail.
+	      O Boleto Bancário será enviado para o seu e-mail.
     </div>
 </div>

--- a/app/design/frontend/base/default/template/vindi_subscription/payment/form/bankslip.phtml
+++ b/app/design/frontend/base/default/template/vindi_subscription/payment/form/bankslip.phtml
@@ -4,6 +4,6 @@
 
 <div id="payment_form_<?php echo $_code ?>" style="display:none;">
     <div class="block-payment-bankslip">
-	      O Boleto Bancário será enviado para o seu e-mail.
+	      O boleto bancário será enviado para o seu e-mail.
     </div>
 </div>


### PR DESCRIPTION
Issue: [#1883](https://github.com/vindi/recurrent/issues/1883)

## Motivação
Atualmente a mensagem para o consumidor ao escolher Boleto como método de pagamento é um pouco confusa.
Mesmo selecionando uma assinatura com periodicidade semanal (por exemplo), é exibida a mensagem:
```` O boleto será enviado mensalmente para o seu email. ````
E na verdade a periodicidade não é mensal.

## Solução Proposta
Juntamente com a Equipe de UX definir e implementar uma mensagem mais agradável ao consumidor;
- Foi selecionada uma mensagem padrão que independe da periodicidade da assinatura
```` O boleto bancário será enviado para o seu e-mail. ````


![image](https://user-images.githubusercontent.com/31661772/52498212-4d787a80-2bbf-11e9-8249-285d82f97b2a.png)
