### PR TITLE
Ajusta comportamento para Webhook de Fatura Criada (bill_created)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [1.4.2 - 19/02/2019](https://github.com/vindi/vindi-magento/releases/tag/1.4.2)
+
+### Corrigido
+- Corrige comportamento da renovação de assinaturas para o Webhook de Fatura Criada
+
+
 ## [1.4.1 - 11/02/2019](https://github.com/vindi/vindi-magento/releases/tag/1.4.1)
 
 ### Corrigido

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -152,18 +152,18 @@ class Vindi_Subscription_Helper_Order
 				->addFieldToFilter('vindi_bill_id', $vindiId)
 				->getFirstItem();
 		}
-    $orders = Mage::getModel('sales/order')
+	    $orders = Mage::getModel('sales/order')
     		->getCollection()
-    	->addAttributeToSelect('*')
-    	->addFieldToFilter('vindi_subscription_id', $vindiId);
-    
-    $lastPeriod = $orders->addFieldToFilter('vindi_subscription_period', $subscriptionPeriod)
+	    	->addAttributeToSelect('*')
+	    	->addFieldToFilter('vindi_subscription_id', $vindiId);
+	    
+	    $lastPeriod = $orders->addFieldToFilter('vindi_subscription_period', $subscriptionPeriod)
     		->getFirstItem();
 
-    if ($lastPeriod->getData()) {
+	    if ($lastPeriod->getData()) {
     		return $lastPeriod;
-    }
-    return $orders->getFirstItem();;
+	    }
+	    return $orders->getFirstItem();;
 	}
 
 	/**

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -152,18 +152,18 @@ class Vindi_Subscription_Helper_Order
 				->addFieldToFilter('vindi_bill_id', $vindiId)
 				->getFirstItem();
 		}
-	    $orders = Mage::getModel('sales/order')
-    		->getCollection()
-	    	->addAttributeToSelect('*')
-	    	->addFieldToFilter('vindi_subscription_id', $vindiId);
-	    
-	    $lastPeriod = $orders->addFieldToFilter('vindi_subscription_period', $subscriptionPeriod)
-    		->getFirstItem();
+		$orders = Mage::getModel('sales/order')
+			->getCollection()
+			->addAttributeToSelect('*')
+			->addFieldToFilter('vindi_subscription_id', $vindiId);
 
-	    if ($lastPeriod->getData()) {
-    		return $lastPeriod;
-	    }
-	    return $orders->getFirstItem();;
+		$lastPeriod = $orders->addFieldToFilter('vindi_subscription_period', $subscriptionPeriod)
+			->getFirstItem();
+
+		if ($lastPeriod->getData()) {
+			return $lastPeriod;
+		}
+		return $orders->getFirstItem();
 	}
 
 	/**

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -143,7 +143,7 @@ class Vindi_Subscription_Helper_Order
 	 *
 	 * @return Mage_Sales_Model_Order
 	 */
-	private function getOrderFromMagento($type, $vindiId, $subscriptionPeriod = null)
+	public function getOrderFromMagento($type, $vindiId, $subscriptionPeriod = null)
 	{
 		if ($type == 'fatura') {
 			return Mage::getModel('sales/order')
@@ -152,12 +152,18 @@ class Vindi_Subscription_Helper_Order
 				->addFieldToFilter('vindi_bill_id', $vindiId)
 				->getFirstItem();
 		}
-		return Mage::getModel('sales/order')
-		    ->getCollection()
-			->addAttributeToSelect('*')
-			->addFieldToFilter('vindi_subscription_id', $vindiId)
-			->addFieldToFilter('vindi_subscription_period', $subscriptionPeriod)
-			->getFirstItem();
+    $orders = Mage::getModel('sales/order')
+    		->getCollection()
+    	->addAttributeToSelect('*')
+    	->addFieldToFilter('vindi_subscription_id', $vindiId);
+    
+    $lastPeriod = $orders->addFieldToFilter('vindi_subscription_period', $subscriptionPeriod)
+    		->getFirstItem();
+
+    if ($lastPeriod->getData()) {
+    		return $lastPeriod;
+    }
+    return $orders->getFirstItem();;
 	}
 
 	/**

--- a/app/code/community/Vindi/Subscription/Helper/Validator.php
+++ b/app/code/community/Vindi/Subscription/Helper/Validator.php
@@ -81,10 +81,7 @@ class Vindi_Subscription_Helper_Validator
 			return false;
 		}
 
-		if (isset($bill['subscription']['id'])
-			&& $bill['period']['cycle']
-			&& ($lastPeriodOrder = $this->billHandler->getLastPeriod($data))
-			&& $lastPeriodOrder->getId()) {
+		if (isset($bill['subscription']['id']) && $bill['period']['cycle']) {
 			$this->billHandler->processBillCreated($data);
 			return true;
 		}

--- a/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.4.1</version>
+            <version>1.4.2</version>
         </Vindi_Subscription>
     </modules>
     <global>

--- a/app/code/community/Vindi/Subscription/etc/system.xml
+++ b/app/code/community/Vindi/Subscription/etc/system.xml
@@ -9,7 +9,7 @@
     <sections>
         <vindi_subscription translate="label" module="vindi_subscription">
             <label>
-                <![CDATA[Vindi Assinaturas]]></label>
+                <![CDATA[Vindi - Configurações]]></label>
             <tab>vindi</tab>
             <frontend_type>text</frontend_type>
             <sort_order>10</sort_order>


### PR DESCRIPTION
## Motivação
Atualmente, se um _webhook_ de renovação for perdido, os _webhooks_ de ciclos posteriores são rejeitados.
A renovação requer que o último ciclo renovado seja exatamente o ciclo **anterior ao atual**.

Ex: 
- Na chegada da renovação [Ciclo: **10**]
- É necessário que o Magento possua o pedido [Ciclo: **9**]
 
## Solução Proposta
- Remover a validação do último ciclo para o webhook **bill_created**;
- Buscar algum pedido da assinatura em questão;
## 
  A renovação será processada se:
  - Houver um pedido **com o ciclo anterior**
  - Houver algum pedido **referente a assinatura** em questão
