### PR TITLE
Ajusta evento 'charge_rejected' para cartão de débito

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [1.5.1 - 04/04/2019](https://github.com/vindi/vindi-magento/releases/tag/1.5.1)
+
+### Ajustado
+- Corrige comportamento do Webhook 'charge_rejected' para cobranças via Cartão de Débito
+
+
 ## [1.5.0 - 01/03/2019](https://github.com/vindi/vindi-magento/releases/tag/1.5.0)
 
 ### Adicionado

--- a/app/code/community/Vindi/Subscription/Helper/Validator.php
+++ b/app/code/community/Vindi/Subscription/Helper/Validator.php
@@ -30,6 +30,10 @@ class Vindi_Subscription_Helper_Validator
 			return false;
 		}
 
+		# Inválida evento se o pedido já estiver pago
+		if ($order->getStatusLabel() == 'processing')
+			return true;
+
 		$gatewayMessage = $charge['last_transaction']['gateway_message'];
 
 		if (is_null($charge['next_attempt'])) {

--- a/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.5.0</version>
+            <version>1.5.1</version>
         </Vindi_Subscription>
     </modules>
     <global>


### PR DESCRIPTION
## Motivação
Caso haja uma nova captura com status rejeitado em uma cobrança já paga, o pedido está sofrendo alterações no Magento.

## Solução Proposta
Bloquear alterações no pedido se a Cobrança já possuir um estado final ('paid')
