### PR TITLE
Altera tipo de Produto utilizado na criação das cobranças

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Notas das versões
 
-## [1.5.1 - 04/04/2019](https://github.com/vindi/vindi-magento/releases/tag/1.5.1)
+## [1.6.0 - 15/04/2019](https://github.com/vindi/vindi-magento/releases/tag/1.6.0)
+
+### Corrigido
+- Corrige status de retorno para os eventos de Webhooks Vindi
 
 ### Ajustado
+- Altera tipo de produto utilizado para geração de cobranças
+
+
+## [1.5.1 - 04/04/2019](https://github.com/vindi/vindi-magento/releases/tag/1.5.1)
+
+### Corrigido
 - Corrige comportamento do Webhook 'charge_rejected' para cobranças via Cartão de Débito
 
 

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -566,7 +566,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
                     $cycles = 1;
                 }
 
-                $list[] = array(
+                array_push($list, array(
                     'product_id'          => $this->findOrCreateProduct(
                         array(
                         	'sku'         => $item->getSku(),
@@ -580,7 +580,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
                         'schema_type'     => 'per_unit'
                     ),
                     'discounts'           => $discount,
-                );
+                ));
             }
         }
         return $this->buildTaxAndshipping($list, $order);
@@ -596,7 +596,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
     public function buildTaxAndshipping($items, $order)
     {
         if ($order->getShippingAmount() > 0) {
-            $items[] = array(
+            array_push($items, array(
                 'product_id'     => $this->findOrCreateProduct(
                     array(
                         'sku'    => 'frete',
@@ -605,11 +605,11 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
                 ),
                 'quantity'       => 1,
                 'pricing_schema' => array('price' => $order->getShippingAmount()),
-            );
+            ));
         }
 
         if (array_key_exists('tax', $order->getQuote()->getTotals())) {
-            $items[] = array(
+            array_push($items, array(
                 'product_id'     => $this->findOrCreateProduct(
                     array(
                         'sku'    => 'taxa',
@@ -620,7 +620,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
                 'pricing_schema' => array(
                     'price'      => $order->getQuote()->getTotals()['tax']->getData('value')
                 ),
-            );
+            ));
         }
         return $items;
     }

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -699,6 +699,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
                 'status'         => 'active',
                 'pricing_schema' => [
                     'price' => 0,
+                    'schema_type': 'per_unit'
                 ],
             ]);
         }

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -665,20 +665,23 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      *
      * @return array|bool|mixed
      */
-    public function findOrCreateUniquePaymentProduct()
-    {
-        $productId = $this->findProductByCode('mag-pagtounico');
-        if (false === $productId) {
-            return $this->createProduct([
-                'name'           => 'Pagamento Único (não remover)',
-                'code'           => 'mag-pagtounico',
-                'status'         => 'active',
-                'pricing_schema' => [
-                    'price' => 0,
-                ],
-            ]);
+    public function findOrCreateUniquePaymentProduct($order)
+    {      
+        $billItems = [];
+        foreach ($order as $item) {
+            $productId = $this->findOrCreateProduct(
+                array(
+                    'sku' => $item->getSku(),
+                    'name' => $item->getName()
+                )
+            );
+
+            $billItems[] = array(
+                'product_id' => $productId,
+                'amount'     => $item->getPrice()
+            );
         }
-        return $productId;
+        return $billItems;
     }
 
     /**
@@ -689,7 +692,6 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      */
     public function findOrCreateProduct($product)
     {
-        //
         $productId = $this->findProductByCode($product['sku']);
 
         if (false === $productId) {
@@ -699,7 +701,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
                 'status'         => 'active',
                 'pricing_schema' => [
                     'price' => 0,
-                    'schema_type': 'per_unit'
+                    'schema_type' => 'per_unit'
                 ],
             ]);
         }

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -566,12 +566,19 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
                 }
 
                 $list[] = array(
-                    'product_id'     => $this->findOrCreateProduct(array(
-                    	'sku' => $item->getSku(),
-                    	'name' => $item->getName())),
-                    'cycles'         => $cycles,
-                    'pricing_schema' => array('price' => $item->getPrice()),
-                    'discounts'      => $discount,
+                    'product_id'          => $this->findOrCreateProduct(
+                        array(
+                        	'sku'         => $item->getSku(),
+                        	'name'        => $item->getName()
+                        )
+                    ),
+                    'cycles'              => $cycles,
+                    'quantity'            => $item->getQtyOrdered(),
+                    'pricing_schema'      => array(
+                        'price'           => $item->getPrice(),
+                        'schema_type'     => 'per_unit'
+                    ),
+                    'discounts'           => $discount,
                 );
             }
         }
@@ -668,7 +675,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
     public function findOrCreateUniquePaymentProduct($order)
     {      
         $billItems = [];
-        foreach ($order as $item) {
+        foreach ($order->getItemsCollection() as $item) {
             $productId = $this->findOrCreateProduct(
                 array(
                     'sku' => $item->getSku(),
@@ -676,9 +683,13 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
                 )
             );
 
-            $billItems[] = array(
-                'product_id' => $productId,
-                'amount'     => $item->getPrice()
+            $billItems = array(
+                'product_id'      => $productId,
+                'quantity'        => $item->getQtyOrdered(),
+                'schema_type'     => array(
+                    'price'       => $item->getPrice(),
+                    'schema_type' => 'per_unit'
+                )
             );
         }
         return $billItems;

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -547,7 +547,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
         $orderDiscount = $order->getDiscountAmount() * -1;
 
         $discount = null;
-        if(!empty($orderDiscount)){
+        if(! empty($orderDiscount)) {
             $discountPercentage = $orderDiscount * 100 / $orderSubtotal;
             $discountPercentage = number_format(floor($discountPercentage*100)/100, 2);
 
@@ -561,7 +561,8 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
             $cycles         = null;
 
             for ($i = 1; $i <= $item->getQtyOrdered(); $i++) {
-                if (Mage::getModel('catalog/product')->load($item->getProductId())->getTypeID() !== 'subscription') {
+                if (Mage::getModel('catalog/product')->load($item->getProductId())->getTypeID()
+                    !== 'subscription') {
                     $cycles = 1;
                 }
 
@@ -582,22 +583,46 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
                 );
             }
         }
+        return $this->buildTaxAndshipping($list, $order);
+    }
 
+    /**
+     * Carrega Frete e Taxa para a Fatura Vindi
+     *
+     * @param array $items, Mage_Sales_Model_Order $order
+     *
+     * @return array
+     */
+    public function buildTaxAndshipping($items, $order)
+    {
         if ($order->getShippingAmount() > 0) {
-            $list[] = array(
-                'product_id'     => $this->findOrCreateProduct(array( 'sku' => 'frete', 'name' => 'Frete')),
+            $items[] = array(
+                'product_id'     => $this->findOrCreateProduct(
+                    array(
+                        'sku'    => 'frete',
+                        'name'   => 'Frete'
+                    )
+                ),
+                'quantity'       => 1,
                 'pricing_schema' => array('price' => $order->getShippingAmount()),
             );
         }
-        
+
         if (array_key_exists('tax', $order->getQuote()->getTotals())) {
-            $list[] = array(
-                'product_id'     => $this->findOrCreateProduct(array( 'sku' => 'taxa', 'name' => 'Taxa')),
-                'pricing_schema' => array('price' => $order->getQuote()->getTotals()['tax']->getData('value')),
+            $items[] = array(
+                'product_id'     => $this->findOrCreateProduct(
+                    array(
+                        'sku'    => 'taxa',
+                        'name'   => 'Taxa'
+                    )
+                ),
+                'quantity'       => 1,
+                'pricing_schema' => array(
+                    'price'      => $order->getQuote()->getTotals()['tax']->getData('value')
+                ),
             );
         }
-
-        return $list;
+        return $items;
     }
 
     /**
@@ -692,7 +717,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
                 )
             ));
         }
-        return $billItems;
+        return $this->buildTaxAndshipping($billItems, $order);
     }
 
     /**

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -686,7 +686,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
             $billItems = array(
                 'product_id'      => $productId,
                 'quantity'        => $item->getQtyOrdered(),
-                'schema_type'     => array(
+                'pricing_schema'     => array(
                     'price'       => $item->getPrice(),
                     'schema_type' => 'per_unit'
                 )

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -674,7 +674,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      */
     public function findOrCreateUniquePaymentProduct($order)
     {      
-        $billItems = [];
+        $billItems = array();
         foreach ($order->getItemsCollection() as $item) {
             $productId = $this->findOrCreateProduct(
                 array(
@@ -683,14 +683,14 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
                 )
             );
 
-            $billItems = array(
+            array_push($billItems, array(
                 'product_id'      => $productId,
                 'quantity'        => $item->getQtyOrdered(),
                 'pricing_schema'     => array(
                     'price'       => $item->getPrice(),
                     'schema_type' => 'per_unit'
                 )
-            );
+            ));
         }
         return $billItems;
     }

--- a/app/code/community/Vindi/Subscription/Helper/Bill.php
+++ b/app/code/community/Vindi/Subscription/Helper/Bill.php
@@ -83,7 +83,25 @@ class Vindi_Subscription_Helper_Bill
 				continue;
 			}
 			$vindiData['products'][] = $billItem;
+
 		}
+                
+		$products = [];
+    	$key = 0;
+
+		foreach ($vindiData['products'] as $product) {
+		    if ($lastCode && $lastCode == $product['product']['code']) {
+		        $products[$key - 1]['quantity'] += $product['quantity'];
+		    	(float)$products[$key - 1]['pricing_schema']['price'] +=
+		    		(float)$product['pricing_schema']['price'];
+		    }
+		    else {
+		        $products[$key] = $product;
+		        $lastCode = $product['product']['code'];
+		    }
+		    $key++;
+		}
+        $vindiData['products'] = $products;
 		return $vindiData;
 	}
 

--- a/app/code/community/Vindi/Subscription/Helper/Bill.php
+++ b/app/code/community/Vindi/Subscription/Helper/Bill.php
@@ -85,24 +85,35 @@ class Vindi_Subscription_Helper_Bill
 			$vindiData['products'][] = $billItem;
 
 		}
-                
-		$products = [];
-    	$key = 0;
-
-		foreach ($vindiData['products'] as $product) {
-		    if ($lastCode && $lastCode == $product['product']['code']) {
-		        $products[$key - 1]['quantity'] += $product['quantity'];
-		    	(float)$products[$key - 1]['pricing_schema']['price'] +=
-		    		(float)$product['pricing_schema']['price'];
-		    }
-		    else {
-		        $products[$key] = $product;
-		        $lastCode = $product['product']['code'];
-		    }
-		    $key++;
-		}
-        $vindiData['products'] = $products;
+		$vindiData['products'] = $this->unifiesProducts($vindiData['products']);
 		return $vindiData;
+	}
+
+	/**
+	 * Unifica os produtos somando os valores e quantidades
+	 *
+	 * @param array | $vindiData['products']
+	 *
+	 * @return array | new $vindiData['products']
+	 */ 
+	public function unifiesProducts($currentData)
+	{
+		$newData = array();
+		$key = 0;
+
+		foreach ($currentData as $product) {
+			if ($lastCode && $lastCode == $product['product']['code']) {
+				$newData[$key - 1]['quantity'] += $product['quantity'];
+				(float)$newData[$key - 1]['pricing_schema']['price'] +=
+				(float)$product['pricing_schema']['price'];
+				$key++;
+				continue;
+			}
+			$newData[$key] = $product;
+			$lastCode = $product['product']['code'];
+			$key++;
+		}
+		return $newData;
 	}
 
 	/**

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -321,7 +321,7 @@ class Vindi_Subscription_Helper_Order
 				$quote->getItemByProduct($magentoProduct)
 					->setOriginalCustomPrice($item['pricing_schema']['price'])
 					->setCustomPrice($item['pricing_schema']['price'])
-        			->setQty($item['quantity'])
+					->setQty($item['quantity'])
 					->save();
 			}
 		}

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -319,8 +319,8 @@ class Vindi_Subscription_Helper_Order
 					$item['pricing_schema']['price']));
 
 				$quote->getItemByProduct($magentoProduct)
-					->setOriginalCustomPrice($item['pricing_schema']['price'])
-					->setCustomPrice($item['pricing_schema']['price'])
+					->setOriginalCustomPrice($item['pricing_schema']['price'] / $item['quantity'])
+					->setCustomPrice($item['pricing_schema']['price'] / $item['quantity'])
 					->setQty($item['quantity'])
 					->save();
 			}

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -321,6 +321,7 @@ class Vindi_Subscription_Helper_Order
 				$quote->getItemByProduct($magentoProduct)
 					->setOriginalCustomPrice($item['pricing_schema']['price'])
 					->setCustomPrice($item['pricing_schema']['price'])
+          			->setQty($item['quantity'])
 					->save();
 			}
 		}

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -321,7 +321,7 @@ class Vindi_Subscription_Helper_Order
 				$quote->getItemByProduct($magentoProduct)
 					->setOriginalCustomPrice($item['pricing_schema']['price'])
 					->setCustomPrice($item['pricing_schema']['price'])
-          			->setQty($item['quantity'])
+        			->setQty($item['quantity'])
 					->save();
 			}
 		}

--- a/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
+++ b/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
@@ -273,9 +273,7 @@ trait Vindi_Subscription_Trait_PaymentProcessor
 		$body = array(
 			'customer_id'         => $customerId,
 			'payment_method_code' => $this->getPaymentMethodCode(),
-			'bill_items'          => array(
-				$this->api()->findOrCreateUniquePaymentProduct($order)
-			)
+			'bill_items'          => $this->api()->findOrCreateUniquePaymentProduct($order)
 		);
 
 		$paymentProfile = $payment->getPaymentProfile();

--- a/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
+++ b/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
@@ -274,7 +274,7 @@ trait Vindi_Subscription_Trait_PaymentProcessor
 			'customer_id'         => $customerId,
 			'payment_method_code' => $this->getPaymentMethodCode(),
 			'bill_items'          => array(
-					$this->api()->findOrCreateUniquePaymentProduct($order)
+				$this->api()->findOrCreateUniquePaymentProduct($order)
 			)
 		);
 

--- a/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
+++ b/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
@@ -270,21 +270,11 @@ trait Vindi_Subscription_Trait_PaymentProcessor
 	 */
 	protected function processSinglePayment($payment, $order, $customerId)
 	{
-		$uniquePaymentProduct = $this->api()->findOrCreateUniquePaymentProduct();
-
-		$this->log(
-			sprintf('Produto para pagamento único: %d.', $uniquePaymentProduct),
-			'vindi_api.log'
-		);
-
 		$body = array(
 			'customer_id'         => $customerId,
 			'payment_method_code' => $this->getPaymentMethodCode(),
 			'bill_items'          => array(
-				array(
-					'product_id' => $uniquePaymentProduct,
-					'amount'     => $order->getGrandTotal(),
-				),
+					$this->api()->findOrCreateUniquePaymentProduct($order)
 			)
 		);
 

--- a/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.5.1</version>
+            <version>1.6.0</version>
         </Vindi_Subscription>
     </modules>
     <global>


### PR DESCRIPTION
Issue: [#2143](https://github.com/vindi/recurrent/issues/2143)
## Motivação
Atualmente utilizamos os produtos do tipo '**preço fixo**' para realizar o processamento de compras no Magento.
Esse modelo influencia negativamente em alteração de produtos no plano, pois em caso de _upgrade_/_downgrade_ (como alteração de quantidade de produtos ou valores), as ações são limitadas, tendo que criar um novo produto na assinatura em questão para processar essa 'adição'. 

## Solução Proposta
- Utilizar produtos do tipo '**preço fixo por quantidade**', onde o preço total dos produtos se basearam no valor base; Sendo assim, uma alteração de quantidade na assinatura, irá refletir na quantidade de itens comprados no Magento.
- Ajustar o Magento para tratar os respectivos falores (produtos/faturas)