### PR TITLE
Ajusta retorno de Webhooks para Vindi

### DIFF
--- a/app/code/community/Vindi/Subscription/Helper/Bill.php
+++ b/app/code/community/Vindi/Subscription/Helper/Bill.php
@@ -88,22 +88,14 @@ class Vindi_Subscription_Helper_Bill
 	}
 
 	/**
-	 * Trata o Webhook 'bill_paid'
-	 * A fatura pode estar relacionada a uma assinatura ou uma compra avulsa
+	 * Registra o pagamento do pedido no Magento
 	 *
-	 * @param array $data
+	 * @param Mage_Sales_Model_Order $order | array $data
 	 *
 	 * @return bool
 	 */
-	public function processBillPaid($data)
+	public function processBillPaid($order, $data)
 	{
-		$order = $this->orderHandler->getOrder($data);
-		if (! $order) {
-			$this->logWebhook(sprintf(
-				'Ainda não existe um pedido para ciclo %s da assinatura: %d.',
-				$data['bill']['period']['cycle'], $data['bill']['subscription']['id']), 4);
-			return false;
-		}
 		return $this->orderHandler->createInvoice($order, $data);
 	}
 }

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -162,8 +162,8 @@ class Vindi_Subscription_Helper_Order
 			return $lastPeriod;
 		}
 
-		$this->logWebhook("Pedido não encontrado para o ciclo: $subscriptionPeriod
-			da Assinatura: $vindiId", 4);
+		$this->logWebhook("Pedido não encontrado para o ciclo: $subscriptionPeriod" . 
+			" da Assinatura: $vindiId", 4);
 
 		return $orders->getFirstItem();
 	}

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -80,7 +80,7 @@ class Vindi_Subscription_Helper_Order
 		}
 
 		if (! $order || ! $order->getId()) {
-			$this->logWebhook(sprintf('Nenhum pedido encontrado para a "%s": %d.', $orderType,
+			$this->logWebhook(sprintf('Pedido não encontrado para a "%s": %d.', $orderType,
 				$orderCode));
 			return false;
 		}

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -161,6 +161,10 @@ class Vindi_Subscription_Helper_Order
 		if ($lastPeriod->getData()) {
 			return $lastPeriod;
 		}
+
+		$this->logWebhook("Pedido não encontrado para o ciclo: $subscriptionPeriod
+			da Assinatura: $vindiId", 4);
+
 		return $orders->getFirstItem();
 	}
 

--- a/app/code/community/Vindi/Subscription/Helper/Validator.php
+++ b/app/code/community/Vindi/Subscription/Helper/Validator.php
@@ -129,6 +129,13 @@ class Vindi_Subscription_Helper_Validator
 		return false;
 	}
 
+	/**
+	 * Carrega informações fatura paga (ID, Tipo, Ciclo)
+	 *
+	 * @param array $bill
+	 *
+	 * @return array
+	 */
 	public function getBillInfo($bill)
 	{
 		if (is_null($bill['subscription'])) {

--- a/app/code/community/Vindi/Subscription/Helper/Validator.php
+++ b/app/code/community/Vindi/Subscription/Helper/Validator.php
@@ -131,7 +131,7 @@ class Vindi_Subscription_Helper_Validator
 
 	public function getBillInfo($bill)
 	{
-		if (is_null($bill['subscription']) {
+		if (is_null($bill['subscription'])) {
 			return array(
 				'type' 	=> 'fatura',
 				'id' 	=> $bill['id'],

--- a/app/code/community/Vindi/Subscription/Helper/WebhookHandler.php
+++ b/app/code/community/Vindi/Subscription/Helper/WebhookHandler.php
@@ -48,7 +48,7 @@ class Vindi_Subscription_Helper_WebhookHandler extends Mage_Core_Helper_Abstract
 		case 'bill_created':
 			return $this->validator->validateBillCreatedWebhook($data);
 		case 'bill_paid':
-			return $this->billHandler->processBillPaid($data);
+			return $this->validator->validateBillPaidWebhook($data);
 		case 'charge_rejected':
 			return $this->validator->validateChargeWebhook($data);
 		default:

--- a/app/code/community/Vindi/Subscription/controllers/WebhookController.php
+++ b/app/code/community/Vindi/Subscription/controllers/WebhookController.php
@@ -24,7 +24,12 @@ class Vindi_Subscription_WebhookController extends Mage_Core_Controller_Front_Ac
 		$body = file_get_contents('php://input');
 		$this->logWebhook(sprintf("Novo evento dos webhooks!\n%s", $body));
 
-		return $handler->handle($body);
+		if (!$handler->handle($body)) {
+            $this->getResponse()->clearHeaders();
+            $this->getResponse()->setHeader('HTTP/1.1','422 Unprocessable Entity');
+            return false;
+        }
+        return true;
 	}
 
 	/**

--- a/app/code/community/Vindi/Subscription/controllers/WebhookController.php
+++ b/app/code/community/Vindi/Subscription/controllers/WebhookController.php
@@ -24,12 +24,12 @@ class Vindi_Subscription_WebhookController extends Mage_Core_Controller_Front_Ac
 		$body = file_get_contents('php://input');
 		$this->logWebhook(sprintf("Novo evento dos webhooks!\n%s", $body));
 
-		if (!$handler->handle($body)) {
-            $this->getResponse()->clearHeaders();
-            $this->getResponse()->setHeader('HTTP/1.1','422 Unprocessable Entity');
-            return false;
-        }
-        return true;
+		if (! $handler->handle($body)) {
+			$this->getResponse()->clearHeaders();
+			$this->getResponse()->setHeader('HTTP/1.1','422 Unprocessable Entity');
+			return false;
+		}
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Issue: [#2144](https://github.com/vindi/recurrent/issues/2144)
## Motivação
Alguns _Webhooks_ não estão retornando o status correto para a Vindi após o processamento.
Esse comportamento afeta a aprovação dos pedidos no Magento.

## Solução Proposta
Ajustar o tratamento dos _Webhooks_, para caso não haja o correto processamento, seja realizada uma retentativa pela Vindi.
Caso o evento seja processado com sucesso, o módulo irá devolver ``status: 200`` => **OK**
