### PR TITLE
Remove estrutura de repetição por quantidade de produtos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [1.6.1 - 16/04/2019](https://github.com/vindi/vindi-magento/releases/tag/1.6.1)
+
+### Corrigido
+- Corrige geração de items duplicados na Fatura Vindi
+
+
 ## [1.6.0 - 15/04/2019](https://github.com/vindi/vindi-magento/releases/tag/1.6.0)
 
 ### Corrigido

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -559,29 +559,26 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
 
         foreach ($orderItems as $item) {
             $cycles         = null;
-
-            for ($i = 1; $i <= $item->getQtyOrdered(); $i++) {
-                if (Mage::getModel('catalog/product')->load($item->getProductId())->getTypeID()
-                    !== 'subscription') {
-                    $cycles = 1;
-                }
-
-                array_push($list, array(
-                    'product_id'          => $this->findOrCreateProduct(
-                        array(
-                        	'sku'         => $item->getSku(),
-                        	'name'        => $item->getName()
-                        )
-                    ),
-                    'cycles'              => $cycles,
-                    'quantity'            => $item->getQtyOrdered(),
-                    'pricing_schema'      => array(
-                        'price'           => $item->getPrice(),
-                        'schema_type'     => 'per_unit'
-                    ),
-                    'discounts'           => $discount,
-                ));
+            if (Mage::getModel('catalog/product')->load($item->getProductId())->getTypeID()
+                !== 'subscription') {
+                $cycles = 1;
             }
+
+            array_push($list, array(
+                'product_id'          => $this->findOrCreateProduct(
+                    array(
+                    	'sku'         => $item->getSku(),
+                    	'name'        => $item->getName()
+                    )
+                ),
+                'cycles'              => $cycles,
+                'quantity'            => $item->getQtyOrdered(),
+                'pricing_schema'      => array(
+                    'price'           => $item->getPrice(),
+                    'schema_type'     => 'per_unit'
+                ),
+                'discounts'           => $discount,
+            ));
         }
         return $this->buildTaxAndshipping($list, $order);
     }

--- a/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.6.0</version>
+            <version>1.6.1</version>
         </Vindi_Subscription>
     </modules>
     <global>


### PR DESCRIPTION
## Motivação
Após a implementação do PR #100 ficou pendente a remoção da repetição por quantidade de pordutos, o que duplica os produtos na fatura Vindi.

## Solução Proposta
Remover a estrutura de repetição desnecessária.
