### PR TITLE
Ajusta alteração de valores do produto no Magento

### DIFF
--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -323,7 +323,7 @@ class Vindi_Subscription_Helper_Order
 					$item['product']['id'],
 					$magentoProduct->getPrice(),
 					$item['pricing_schema']['price']));
-            }
+			}
 
 			$quote->getItemByProduct($magentoProduct)
 				->setOriginalCustomPrice($item['pricing_schema']['price'])

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -308,8 +308,10 @@ class Vindi_Subscription_Helper_Order
 			if (! $magentoProduct) {
 				$this->logWebhook(sprintf('O produto com ID Vindi #%s não existe no Magento.',
 					$item['product']['id']), 5);
+				continue;
 			}
-			elseif (number_format($magentoProduct->getPrice(), 2)
+
+			if (number_format($magentoProduct->getPrice(), 2)
 				!== number_format($item['pricing_schema']['price'], 2)) {
 
 				$this->logWebhook(sprintf("Divergencia de valores na fatura #%s:  " . 
@@ -321,13 +323,13 @@ class Vindi_Subscription_Helper_Order
 					$item['product']['id'],
 					$magentoProduct->getPrice(),
 					$item['pricing_schema']['price']));
+            }
 
-				$quote->getItemByProduct($magentoProduct)
-					->setOriginalCustomPrice($item['pricing_schema']['price'] / $item['quantity'])
-					->setCustomPrice($item['pricing_schema']['price'] / $item['quantity'])
-					->setQty($item['quantity'])
-					->save();
-			}
+			$quote->getItemByProduct($magentoProduct)
+				->setOriginalCustomPrice($item['pricing_schema']['price'])
+				->setCustomPrice($item['pricing_schema']['price'])
+				->setQty($item['quantity'])
+				->save();
 		}
 		$quote->setTotalsCollectedFlag(false)
 			->collectTotals()


### PR DESCRIPTION
## Motivação
Os valores e a quantidade de produtos no pedido só estão sendo alterados se houver divergência no preço unitário dos produtos.
A alteração deve ser realizada em toda renovação. 

## Solução Proposta
Mover a atualização de valores e quantidade para fora da validação de divergência:
- Se houver divergência de valores, será logada uma mensagem
- Sempre serão alterados valores e quantidade dos produtos no pedido
