### PR TITLE
Ajusta status do retorno para Webhook de Teste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Notas das versões
 
+## [1.6.2 - 17/04/2019](https://github.com/vindi/vindi-magento/releases/tag/1.6.2)
+
+### Ajustado
+- Ajusta alteração de valores do produto no Magento
+- Ajusta status do retorno para Webhook de Teste
+
+
 ## [1.6.1 - 16/04/2019](https://github.com/vindi/vindi-magento/releases/tag/1.6.1)
 
 ### Corrigido

--- a/app/code/community/Vindi/Subscription/Helper/WebhookHandler.php
+++ b/app/code/community/Vindi/Subscription/Helper/WebhookHandler.php
@@ -44,7 +44,7 @@ class Vindi_Subscription_Helper_WebhookHandler extends Mage_Core_Helper_Abstract
 
 		case 'test':
 			$this->logWebhook('Evento de teste do webhook.');
-			return false;
+			return true;
 		case 'bill_created':
 			return $this->validator->validateBillCreatedWebhook($data);
 		case 'bill_paid':

--- a/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.6.1</version>
+            <version>1.6.2</version>
         </Vindi_Subscription>
     </modules>
     <global>


### PR DESCRIPTION
## Motivação
O evento de testes dos Webhooks Vindi está sendo respondido com o status: 422
Como esse teste serve para validar a comunicação entre Vindi x Magento, é importante o servidor retornar o status correto.

## Solução Proposta
Retornar status: 200 no processamento do evento **test**
