### PR TITLE
Ajusta fluxo de cancelamento de assinaturas após pagamento rejeitado

### DIFF
--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -477,7 +477,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      *
      * @param $vindiId
      */
-    public function deletePurchase($vindiId, $type)
+    public function cancelPurchase($vindiId, $type)
     {
         $this->request("{$type}/{$vindiId}", 'DELETE');
     }

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -473,7 +473,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
     }
 
     /**
-     * Cancela a assinatura e fatura na Vindi após falha no pagamento
+     * Cancela assinaturas e faturas na Vindi após falha no pagamento
      *
      * @param $vindiId
      */

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -473,11 +473,13 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
     }
 
     /**
-     * @param $billId
+     * Cancela a assinatura e fatura na Vindi após falha no pagamento
+     *
+     * @param $vindiId
      */
-    public function deleteBill($billId)
+    public function deletePurchase($vindiId, $type)
     {
-        $this->request("bills/{$billId}", 'DELETE');
+        $this->request("{$type}/{$vindiId}", 'DELETE');
     }
 
     /**

--- a/app/code/community/Vindi/Subscription/Helper/Bill.php
+++ b/app/code/community/Vindi/Subscription/Helper/Bill.php
@@ -99,6 +99,7 @@ class Vindi_Subscription_Helper_Bill
 	public function unifiesProducts($currentData)
 	{
 		$newData = array();
+		$lastCode = null;
 		$key = 0;
 
 		foreach ($currentData as $product) {

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -51,7 +51,7 @@ class Vindi_Subscription_Helper_Order
 		if (! $bill) {
 			return false;
 		}
-		return $this->getOrder(compact('bill'));
+		return compact('bill');
 	}
 
 	/**
@@ -80,15 +80,6 @@ class Vindi_Subscription_Helper_Order
 		}
 
 		if (! $order || ! $order->getId()) {
-
-			# Ignora evento se for o primeiro ciclo de uma assinatura via cartão de crédito;
-			# Com exceção de transações com suspeita de fraude, 
-			# o Magento exclui o pedido caso o pagamento seja imediatamente rejeitado.
-			# Desse modo, não é possível realizar alterações no pedido
-			if (reset($data['bill']['charges'])['payment_method']['type'] == 'PaymentMethod::CreditCard' &&
-				$data['bill']['period']['cycle'] == 1)
-				return true;
-
 			$this->logWebhook(sprintf('Pedido não encontrado para a "%s": %d.', $orderType,
 				$orderCode));
 			return false;

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -49,7 +49,7 @@ class Vindi_Subscription_Helper_Order
 		$bill = $api->getBill($billId);
 
 		if (! $bill) {
-			return false;
+			return null;
 		}
 		return compact('bill');
 	}

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -107,21 +107,15 @@ class Vindi_Subscription_Helper_Order
 	public function createInvoice($order, $data)
 	{
 		$orderId = $order->getId();
-		if ($orderId) {
-			if ($order->canInvoice()) {
-				$this->logWebhook('Gerando fatura para o pedido: ' . $orderId);
-				$this->updateToSuccess($order);
-				$paymentMethod = new Vindi_Subscription_Model_PaymentMethod();
-				$paymentMethod->processPaidReturn($data['bill'], $order);
-				$this->logWebhook('Fatura gerada com sucesso.');
-				return true;
-			}
-			elseif ($order->canHold()) {
-				$this->logWebhook(
-					'O pedido ' . $orderId . 'estava com o status:' . $order->getState()
-				);
-				return true;
-			}
+		if ($orderId && $order->canInvoice()) {
+			$this->logWebhook('Gerando fatura para o pedido: ' . $orderId);
+			$this->updateToSuccess($order);
+			$paymentMethod = new Vindi_Subscription_Model_PaymentMethod();
+			$paymentMethod->processPaidReturn($data['bill'], $order);
+			$this->logWebhook('Fatura gerada com sucesso.');
+			return true;
+		}
+		elseif ($orderId) { 
 			$this->logWebhook('Impossível gerar fatura para o pedido ' . $orderId, 4);
 		}
 		return false;

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -80,6 +80,15 @@ class Vindi_Subscription_Helper_Order
 		}
 
 		if (! $order || ! $order->getId()) {
+
+			# Ignora evento se for o primeiro ciclo de uma assinatura via cartão de crédito;
+			# Com exceção de transações com suspeita de fraude, 
+			# o Magento exclui o pedido caso o pagamento seja imediatamente rejeitado.
+			# Desse modo, não é possível realizar alterações no pedido
+			if (reset($data['bill']['charges'])['payment_method']['type'] == 'PaymentMethod::CreditCard' &&
+				$data['bill']['period']['cycle'] == 1)
+				return true;
+
 			$this->logWebhook(sprintf('Pedido não encontrado para a "%s": %d.', $orderType,
 				$orderCode));
 			return false;
@@ -98,15 +107,21 @@ class Vindi_Subscription_Helper_Order
 	public function createInvoice($order, $data)
 	{
 		$orderId = $order->getId();
-		if ($orderId && $order->canInvoice()) {
-			$this->logWebhook('Gerando fatura para o pedido: ' . $orderId);
-			$this->updateToSuccess($order);
-			$paymentMethod = new Vindi_Subscription_Model_PaymentMethod();
-			$paymentMethod->processPaidReturn($data['bill'], $order);
-			$this->logWebhook('Fatura gerada com sucesso.');
-			return true;
-		}
-		elseif ($orderId) { 
+		if ($orderId) {
+			if ($order->canInvoice()) {
+				$this->logWebhook('Gerando fatura para o pedido: ' . $orderId);
+				$this->updateToSuccess($order);
+				$paymentMethod = new Vindi_Subscription_Model_PaymentMethod();
+				$paymentMethod->processPaidReturn($data['bill'], $order);
+				$this->logWebhook('Fatura gerada com sucesso.');
+				return true;
+			}
+			elseif ($order->canHold()) {
+				$this->logWebhook(
+					'O pedido ' . $orderId . 'estava com o status:' . $order->getState()
+				);
+				return true;
+			}
 			$this->logWebhook('Impossível gerar fatura para o pedido ' . $orderId, 4);
 		}
 		return false;

--- a/app/code/community/Vindi/Subscription/Helper/Validator.php
+++ b/app/code/community/Vindi/Subscription/Helper/Validator.php
@@ -25,17 +25,16 @@ class Vindi_Subscription_Helper_Validator
 		$charge = $data['charge'];
 		$order = $this->orderHandler->getOrderFromVindi($charge['bill']['id']);
 		
-		if (! $order) {
-			$this->logWebhook('Pedido não encontrado.', 4);
-			return false;
+		if (! $order || true === $order) {
+			return $order;
 		}
 
 		# Inválida evento se a cobrança já estiver paga
-		if (($chargeStatus = $charge['status']) == 'paid') {
+		if (! $order->canInvoice()) {
 			$orderStatus = $order->getStatusLabel();
 			$this->logWebhook('Evento não processado!');
-			$this->logWebhook("O pedido possui o status: '$orderStatus' e " .
-				"a cobrança possui o status: '$chargeStatus'");	
+			$this->logWebhook('O pedido possui o status: $orderStatus e ' .
+				'a cobrança possui o status:'. $charge['status']);	
 			return true;
 		}
 

--- a/app/code/community/Vindi/Subscription/Helper/Validator.php
+++ b/app/code/community/Vindi/Subscription/Helper/Validator.php
@@ -24,6 +24,10 @@ class Vindi_Subscription_Helper_Validator
 	{
 		$charge = $data['charge'];
 		$vindiOrder = $this->orderHandler->getOrderFromVindi($charge['bill']['id']);
+
+		if (is_null($vindiOrder))
+			return false;
+		
 		$paymentMethod = reset($vindiOrder['bill']['charges'])['payment_method']['type'];
 
 		# Ignora evento se for o primeiro ciclo de uma assinatura via cartão de crédito;

--- a/app/code/community/Vindi/Subscription/Helper/Validator.php
+++ b/app/code/community/Vindi/Subscription/Helper/Validator.php
@@ -29,7 +29,7 @@ class Vindi_Subscription_Helper_Validator
 			return $order;
 		}
 
-		# Inválida evento se a cobrança já estiver paga
+		# Invalida evento se a cobrança já estiver paga
 		if (! $order->canInvoice()) {
 			$orderStatus = $order->getStatusLabel();
 			$this->logWebhook('Evento não processado!');

--- a/app/code/community/Vindi/Subscription/Helper/Validator.php
+++ b/app/code/community/Vindi/Subscription/Helper/Validator.php
@@ -40,7 +40,7 @@ class Vindi_Subscription_Helper_Validator
 			return true;
 		}
 
-		$this->orderHandler->getOrder($vindiOrder);
+		$order = $this->orderHandler->getOrder($vindiOrder);
 		
 		if (! $order) {
 			$this->logWebhook('Pedido não encontrado.', 4);

--- a/app/code/community/Vindi/Subscription/Helper/Validator.php
+++ b/app/code/community/Vindi/Subscription/Helper/Validator.php
@@ -38,8 +38,9 @@ class Vindi_Subscription_Helper_Validator
 
 		$this->orderHandler->getOrder($vindiOrder);
 		
-		if (! $order || true === $order) {
-			return $order;
+		if (! $order) {
+			$this->logWebhook('Pedido não encontrado.', 4);
+			return false;
 		}
 
 		# Invalida evento se a cobrança já estiver paga

--- a/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
+++ b/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
@@ -374,11 +374,12 @@ trait Vindi_Subscription_Trait_PaymentProcessor
 				$type = 'subscriptions';
 			}
 
-			if ($paymentMethod = reset($payment['charges'])['payment_method']['code'] === "bank_slip"
-				|| $paymentMethod === "debit_card"
-				|| $payment['status'] === "paid"
-				|| $payment['status'] === "review"
-				|| reset($payment['charges'])['status'] === "fraud_review")
+			$paymentMethod = reset($payment['charges'])['payment_method']['type'];
+			if ($paymentMethod === 'PaymentMethod::BankSlip'
+				|| $paymentMethod === 'PaymentMethod::DebitCard'
+				|| $payment['status'] === 'paid'
+				|| $payment['status'] === 'review'
+				|| reset($payment['charges'])['status'] === 'fraud_review')
 				return $payment;
 
 			$this->api()->deletePurchase($vindiId, $type);

--- a/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
+++ b/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
@@ -288,34 +288,13 @@ trait Vindi_Subscription_Trait_PaymentProcessor
 			$body['installments'] = (int) $installments;
 		}
 
-		if ($bill = $this->api()->createBill($body)) {
-			if ($body['payment_method_code'] === "bank_slip"
-				|| $body['payment_method_code'] === "debit_card"
-				|| $bill['status'] === "paid"
-				|| $bill['status'] === "review"
-				|| $bill['charges'][0]['status'] === "fraud_review") {
-				$order->setVindiBillId($bill['id']);
-				$order->save();
-				return $bill;
-			}
-			$this->api()->deleteBill($bill['id']);
+		$bill = $this->api()->createBill($body);
+
+		if ($this->validatePayment($bill, $order, $payment)) {
+			$order->setVindiBillId($bill['id']);
+			$order->save();
+			return $bill;
 		}
-
-		$this->log(
-			sprintf('Erro no pagamento do pedido %d.', $order->getId()),
-			'vindi_api.log'
-		);
-
-		$message = 'Houve um problema na confirmação do pagamento.' .
-		'Verifique os dados e tente novamente.';
-
-		$payment->setStatus(
-			Mage_Sales_Model_Order::STATE_CANCELED,
-			Mage_Sales_Model_Order::STATE_CANCELED,
-			$message,
-			true
-		);
-		$this->error($message);
 	}
 
 	/**
@@ -366,26 +345,52 @@ trait Vindi_Subscription_Trait_PaymentProcessor
 
 		$this->log(json_encode($payment->getAdditionalInformation()), $this->_code . '.log');
 
-		if (! isset($subscription['id']) || empty($subscription['id'])) {
-			$message = sprintf('Pagamento Falhou. (%s)', $this->api()->lastError);
+		if ($this->validatePayment($subscription, $order, $payment)) {
+			$order->setVindiSubscriptionId($subscription['id']);
+			$order->setVindiBillId($subscription['bill']['id']);
+			$order->setVindiSubscriptionPeriod(1);
+			$order->save();
+			return $subscription;
+		}
+	}
 
-			$this->log(
-				sprintf('Erro no pagamento do pedido %s.\n%s', $order->getId(), $message),
-				'vindi_api.log'
-			);
+	public function cancelOrder($order)
+	{
+		$order->setStatus(
+			Mage_Sales_Model_Order::STATE_CANCELED,
+			Mage_Sales_Model_Order::STATE_CANCELED,
+			'Houve um problema na confirmação do pagamento.',
+			true
+		);
+	}
 
-			$this->error($message);
+	public function validatePayment($payment, $order, $orderAttempt)
+	{
+		$type = 'bills';
+		if($payment && $payment['id']) {
+			$vindiId = $payment['id'];
+			if (! $this->isSingleOrder($order)) {
+				$payment = $payment['bill'];
+				$type = 'subscriptions';
+			}
 
-			// TODO update order status?
-			return false;
+			if ($paymentMethod = reset($payment['charges'])['payment_method']['code'] === "bank_slip"
+				|| $paymentMethod === "debit_card"
+				|| $payment['status'] === "paid"
+				|| $payment['status'] === "review"
+				|| reset($payment['charges'])['status'] === "fraud_review")
+				return $payment;
+
+			$this->api()->deletePurchase($vindiId, $type);
 		}
 
-		$order->setVindiSubscriptionId($subscription['id']);
-		$order->setVindiBillId($subscription['bill']['id']);
-		$order->setVindiSubscriptionPeriod(1);
-		$order->save();
-
-		return $subscription;
+		$this->cancelOrder($orderAttempt);
+		$this->log(
+			sprintf('Erro no pagamento do pedido %d.', $order->getId()), 'vindi_api.log'
+		);
+		$message = 'Houve um problema na confirmação do pagamento.' .
+		'Verifique os dados e tente novamente.';
+		$this->error($message);
 	}
 
 	public function getCurrentVindiPlan($product)

--- a/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
+++ b/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
@@ -389,7 +389,7 @@ trait Vindi_Subscription_Trait_PaymentProcessor
 		$this->log(
 			sprintf('Erro no pagamento do pedido %d.', $order->getId()), 'vindi_api.log'
 		);
-		$message = 'Houve um problema na confirmação do pagamento.' .
+		$message = 'Houve um problema na confirmação do pagamento. ' .
 		'Verifique os dados e tente novamente.';
 		$this->error($message);
 	}

--- a/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
+++ b/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
@@ -382,7 +382,7 @@ trait Vindi_Subscription_Trait_PaymentProcessor
 				|| reset($payment['charges'])['status'] === 'fraud_review')
 				return $payment;
 
-			$this->api()->deletePurchase($vindiId, $type);
+			$this->api()->cancelPurchase($vindiId, $type);
 		}
 
 		$this->cancelOrder($orderAttempt);


### PR DESCRIPTION
## Motivação
Atualmente nossos plugins por padrão cancelam uma assinatura caso o pagamento do primeiro ciclo seja rejeitado.
- O Magento está cancelando apenas compras avulsas automaticamente :heavy_check_mark: 
- Assinaturas estão sendo mantidas como **Aguardando Pagamento** :x: 
O fluxo deve ser padronizado entre os plugins :checkered_flag: 
- Caso o resultado de pagamento do pedido seja assíncrono, o Magento deve tratar corretamente os _Webhooks_ (**Charge Rejected**) recebidos

## Solução Proposta
- Inserir o cancelamento automático de assinaturas caso o pagamento do primeiro ciclo seja rejeitado
- Ajustar o tratamento do evento **Charge Rejected** para se adequar ao novo comportamento
