### PR TITLE
Adiciona validação de pedidos finalizados para Webhook de Fatura Paga

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Notas das versões
 
+## [1.7.0 - 23/04/2019](https://github.com/vindi/vindi-magento/releases/tag/1.7.0)
+
+### Adicionado
+- Adiciona validação de pedidos finalizados para Webhook de Fatura Paga
+- Adiciona fluxo de cancelamento de assinaturas após pagamento rejeitado
+- Associa ID da fatura Vindi ao pedido no Magento 
+
+
 ## [1.6.2 - 17/04/2019](https://github.com/vindi/vindi-magento/releases/tag/1.6.2)
 
 ### Ajustado

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -205,6 +205,7 @@ class Vindi_Subscription_Helper_Order
 	public function renewalOrder($order, $vindiData, $charges)
 	{
 		$order->setVindiSubscriptionId($vindiData['bill']['subscription']);
+		$order->setVindiBillId($vindiData['bill']['id']);	
 		$order->setVindiSubscriptionPeriod($vindiData['bill']['cycle']);
 		$order->setBaseGrandTotal($vindiData['bill']['amount']);
 		$order->setGrandTotal($vindiData['bill']['amount']);

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -98,15 +98,19 @@ class Vindi_Subscription_Helper_Order
 	public function createInvoice($order, $data)
 	{
 		$orderId = $order->getId();
-		if ($orderId && $order->canInvoice()) {
-			$this->logWebhook('Gerando fatura para o pedido: ' . $orderId);
-			$this->updateToSuccess($order);
-			$paymentMethod = new Vindi_Subscription_Model_PaymentMethod();
-			$paymentMethod->processPaidReturn($data['bill'], $order);
-			$this->logWebhook('Fatura gerada com sucesso.');
-			return true;
-		}
-		elseif ($orderId) { 
+		if ($orderId) {
+			if ($order->canInvoice()) {
+				$this->logWebhook('Gerando fatura para o pedido: ' . $orderId);
+				$this->updateToSuccess($order);
+				$paymentMethod = new Vindi_Subscription_Model_PaymentMethod();
+				$paymentMethod->processPaidReturn($data['bill'], $order);
+				$this->logWebhook('Fatura gerada com sucesso.');
+				return true;
+			}
+			elseif ($order->canHold()) {
+				$this->logWebhook('O pedido ' . $orderId . 'estava com o status:' . $order->getState());
+				return true;
+			}
 			$this->logWebhook('Impossível gerar fatura para o pedido ' . $orderId, 4);
 		}
 		return false;

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -108,7 +108,7 @@ class Vindi_Subscription_Helper_Order
 				return true;
 			}
 			elseif ($order->canHold()) {
-				$this->logWebhook('O pedido ' . $orderId . 'estava com o status:' . $order->getState());
+				$this->logWebhook('O pedido ' . $orderId . 'possui o status:' . $order->getState());
 				return true;
 			}
 			$this->logWebhook('Impossível gerar fatura para o pedido ' . $orderId, 4);

--- a/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.6.2</version>
+            <version>1.7.0</version>
         </Vindi_Subscription>
     </modules>
     <global>


### PR DESCRIPTION
## Motivação
Atualmente, Os pedidos já finalizados (Processados ou Concluídos) no Magento não são atualizados pela nossa Integração.
- Caso o pedido não tenha sido faturado
  - Deve ser criada uma _invoice_ no Pedido (alterando o mesmo para **processing**) :heavy_check_mark: 
- Caso o pedido já tenha sido faturado
  - O Webhook deve ser ignorado (retornando status: 200 para a Vindi) :heavy_check_mark: 
  - O Webhook está sendo ignorado (retornando status: 422 para a Vindi) :x: 
    - **Entrando no fluxo de retentativas de envio (por 48 horas)** :warning: 

## Solução Proposta
- Inserir a validação para **pedidos já finalizados** para o _Webhook_ de **Fatura Paga**
- Retornar o status: 200 (_Evitando retentativas desnecessárias_)