### PR TITLE
Salva informações de pagamento no pedido

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [1.7.1 - 03/05/2019](https://github.com/vindi/vindi-magento/releases/tag/1.7.1)
+
+### Corrigido
+- Persiste os dados do método de pagamento no pedido Magento
+
+
 ## [1.7.0 - 23/04/2019](https://github.com/vindi/vindi-magento/releases/tag/1.7.0)
 
 ### Adicionado

--- a/app/code/community/Vindi/Subscription/Model/PaymentMethod.php
+++ b/app/code/community/Vindi/Subscription/Model/PaymentMethod.php
@@ -155,6 +155,7 @@ class Vindi_Subscription_Model_PaymentMethod extends Mage_Payment_Model_Method_A
 		}
 
 		$payment->setAdditionalInformation($additionalInfo);
+		$payment->save();
 		return true;
 	}
 

--- a/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.7.0</version>
+            <version>1.7.1</version>
         </Vindi_Subscription>
     </modules>
     <global>


### PR DESCRIPTION
## Motivação
As informações de pagamento do pedido não estão sendo salvas, pois não foi forçado o método **save()** durante a alteração.

## Solução Proposta
Inserir o **save()** no pedido após a adição das informações de pagamento.
