### PR TITLE
Ajusta tratativa de webhooks [Bill Paid / Bill Created]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [1.8.0 - 03/06/2019](https://github.com/vindi/vindi-magento/releases/tag/1.8.0)
+
+### Ajustado
+- Ajusta tratativa de Webhooks (Fatura Criada e Fatura Paga)
+
+
 ## [1.7.1 - 03/05/2019](https://github.com/vindi/vindi-magento/releases/tag/1.7.1)
 
 ### Corrigido

--- a/app/code/community/Vindi/Subscription/Helper/Bill.php
+++ b/app/code/community/Vindi/Subscription/Helper/Bill.php
@@ -22,7 +22,7 @@ class Vindi_Subscription_Helper_Bill
 	{
 		$bill = $data['bill'];
 		$vindiData = $this->loadBillData($data);
-		$lastOrder = $this->getLastPeriod($data);
+		$lastOrder = $this->getLastPeriod($bill);
 
 		$order = $this->orderHandler->createOrder($lastOrder, $vindiData);
 

--- a/app/code/community/Vindi/Subscription/Helper/Bill.php
+++ b/app/code/community/Vindi/Subscription/Helper/Bill.php
@@ -21,7 +21,7 @@ class Vindi_Subscription_Helper_Bill
 	public function processBillCreated($data)
 	{
 		$bill = $data['bill'];
-		$vindiData = $this->loadBillData($data);
+		$vindiData = $this->loadBillData($bill);
 		$lastOrder = $this->getLastPeriod($bill);
 
 		$order = $this->orderHandler->createOrder($lastOrder, $vindiData);

--- a/app/code/community/Vindi/Subscription/Helper/Bill.php
+++ b/app/code/community/Vindi/Subscription/Helper/Bill.php
@@ -18,11 +18,13 @@ class Vindi_Subscription_Helper_Bill
 	 *
 	 * @return bool
 	 */
-	public function processBillCreated($data)
+	public function processBillCreated($bill)
 	{
-		$bill = $data['bill'];
 		$vindiData = $this->loadBillData($bill);
 		$lastOrder = $this->getLastPeriod($bill);
+
+		if (! $lastOrder->getId())
+			return false;
 
 		$order = $this->orderHandler->createOrder($lastOrder, $vindiData);
 
@@ -44,10 +46,10 @@ class Vindi_Subscription_Helper_Bill
 	 *
 	 * @return bool|Mage_Sales_Model_Order
 	 */
-	public function getLastPeriod($data)
+	public function getLastPeriod($bill)
 	{
-		$currentPeriod = $data['period']['cycle'];
-		$subscriptionId = $data['subscription']['id'];
+		$currentPeriod = $bill['period']['cycle'];
+		$subscriptionId = $bill['subscription']['id'];
 		return $this->orderHandler->getOrderFromMagento('subscription',
 			$subscriptionId, $currentPeriod - 1);
 	}
@@ -125,8 +127,8 @@ class Vindi_Subscription_Helper_Bill
 	 *
 	 * @return bool
 	 */
-	public function processBillPaid($order, $data)
+	public function processBillPaid($order, $bill)
 	{
-		return $this->orderHandler->createInvoice($order, $data);
+		return $this->orderHandler->createInvoice($order, $bill);
 	}
 }

--- a/app/code/community/Vindi/Subscription/Helper/Bill.php
+++ b/app/code/community/Vindi/Subscription/Helper/Bill.php
@@ -46,8 +46,8 @@ class Vindi_Subscription_Helper_Bill
 	 */
 	public function getLastPeriod($data)
 	{
-		$currentPeriod = $data['bill']['period']['cycle'];
-		$subscriptionId = $data['bill']['subscription']['id'];
+		$currentPeriod = $data['period']['cycle'];
+		$subscriptionId = $data['subscription']['id'];
 		return $this->orderHandler->getOrderFromMagento('subscription',
 			$subscriptionId, $currentPeriod - 1);
 	}
@@ -63,17 +63,17 @@ class Vindi_Subscription_Helper_Bill
 	{
 		$vindiData = [
 			'bill'     => [
-				'id'           => $data['bill']['id'],
-				'amount'       => $data['bill']['amount'],
-				'subscription' => $data['bill']['subscription']['id'],
-				'cycle'        => $data['bill']['period']['cycle']
+				'id'           => $data['id'],
+				'amount'       => $data['amount'],
+				'subscription' => $data['subscription']['id'],
+				'cycle'        => $data['period']['cycle']
 			],
 			'products' => [],
 			'shipping' => [],
 			'taxes'    => [],
 		];
 
-		foreach ($data['bill']['bill_items'] as $billItem) {
+		foreach ($data['bill_items'] as $billItem) {
 			if ($billItem['product']['code'] == 'frete') {
 				$vindiData['shipping'] = $billItem;
 				continue;

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -95,7 +95,7 @@ class Vindi_Subscription_Helper_Order
 	 *
 	 * @return bool
 	 */
-	public function createInvoice($order, $data)
+	public function createInvoice($order, $bill)
 	{
 		$orderId = $order->getId();
 		if ($orderId) {
@@ -103,12 +103,12 @@ class Vindi_Subscription_Helper_Order
 				$this->logWebhook('Gerando fatura para o pedido: ' . $orderId);
 				$this->updateToSuccess($order);
 				$paymentMethod = new Vindi_Subscription_Model_PaymentMethod();
-				$paymentMethod->processPaidReturn($data['bill'], $order);
+				$paymentMethod->processPaidReturn($bill, $order);
 				$this->logWebhook('Fatura gerada com sucesso.');
 				return true;
 			}
 			elseif ($order->canHold()) {
-				$this->logWebhook('O pedido ' . $orderId . 'possui o status:' . $order->getState());
+				$this->logWebhook("O pedido $orderId possui o status: '$order->getState()'");
 				return true;
 			}
 			$this->logWebhook('Impossível gerar fatura para o pedido ' . $orderId, 4);
@@ -165,10 +165,6 @@ class Vindi_Subscription_Helper_Order
 		if ($lastPeriod->getData()) {
 			return $lastPeriod;
 		}
-
-		$this->logWebhook("Pedido não encontrado para o ciclo: $subscriptionPeriod" . 
-			" da Assinatura: $vindiId", 4);
-
 		return $orders->getFirstItem();
 	}
 
@@ -223,7 +219,7 @@ class Vindi_Subscription_Helper_Order
 			}
 		}
 		$this->logWebhook(sprintf('Novo pedido gerado: %s.', $order->getId()));
-		return true;
+		return $order;
 	}
 
 	/*

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -51,7 +51,7 @@ class Vindi_Subscription_Helper_Order
 		if (! $bill) {
 			return null;
 		}
-		return compact('bill');
+		return $bill;
 	}
 
 	/**
@@ -63,18 +63,18 @@ class Vindi_Subscription_Helper_Order
 	 */
 	public function getOrder($data)
 	{
-		if (! isset($data['bill'])) {
+		if (! isset($data)) {
 			return false;
 		}
 
-		$orderCode = filter_var($data['bill']['subscription']['id'], FILTER_SANITIZE_NUMBER_INT);
-		if (isset($data['bill']['subscription']['id']) && $orderCode) {
+		$orderCode = filter_var($data['subscription']['id'], FILTER_SANITIZE_NUMBER_INT);
+		if (isset($data['subscription']['id']) && $orderCode) {
 			$orderType = 'assinatura';
 			$order = $this->getOrderFromMagento($orderType,
-				$orderCode, $data['bill']['period']['cycle']);
+				$orderCode, $data['period']['cycle']);
 		}
 		else {
-			$orderCode = filter_var($data['bill']['id'], FILTER_SANITIZE_NUMBER_INT);
+			$orderCode = filter_var($data['id'], FILTER_SANITIZE_NUMBER_INT);
 			$orderType = 'fatura';
 			$order = $this->getOrderFromMagento($orderType, $orderCode);
 		}

--- a/app/code/community/Vindi/Subscription/Helper/Validator.php
+++ b/app/code/community/Vindi/Subscription/Helper/Validator.php
@@ -106,7 +106,7 @@ class Vindi_Subscription_Helper_Validator
 		}
 
 		if (! $this->orderHandler->getOrder($bill)) {
-			$this->billHandler->processBillCreated($bill);
+			$this->billHandler->processBillCreated(compact('bill'));
 		}
 
 		if ($this->orderHandler->getOrder($bill) && $bill['status'] === 'paid') {
@@ -136,7 +136,7 @@ class Vindi_Subscription_Helper_Validator
 		if (! $order)
 			return $this->validateBillCreatedWebhook($data);
 
-		if ($order && ! $order->canHold() && $order->canInvoice())
+		if ($order && $order->canInvoice())
 			return $this->billHandler->processBillPaid($order, $data);
 
 		// if ($billInfo['type'] == 'assinatura') {

--- a/app/code/community/Vindi/Subscription/Helper/Validator.php
+++ b/app/code/community/Vindi/Subscription/Helper/Validator.php
@@ -46,6 +46,8 @@ class Vindi_Subscription_Helper_Validator
 			return false;
 		}
 
+		$charge = reset($vindiOrder['charges']);
+
 		# Invalida evento se a cobrança já estiver paga
 		if (! $order->canInvoice()) {
 			$orderStatus = $order->getStatusLabel();
@@ -55,7 +57,6 @@ class Vindi_Subscription_Helper_Validator
 			return true;
 		}
 
-		$charge = reset($vindiOrder['charges']);
 		$gatewayMessage = $charge['last_transaction']['gateway_message'];
 
 		if (is_null($charge['next_attempt'])) {

--- a/app/code/community/Vindi/Subscription/Helper/Validator.php
+++ b/app/code/community/Vindi/Subscription/Helper/Validator.php
@@ -95,21 +95,15 @@ class Vindi_Subscription_Helper_Validator
 			return true;
 		}
 
-		if (isset($bill['period']) && ($bill['period']['cycle'] === 1)) {
-			$this->logWebhook(sprintf(
-				'Ignorando o evento "bill_created" para pedido concluído.'), 7);
-			return true;
+		if (! isset($bill['subscription']['id']) || ! isset($bill['period']['cycle'])) {
+			$this->logWebhook('Pedido anterior não encontrado. Ignorando evento.', 4);
+			return false;
 		}
 
 		if (isset($bill['period']) && ($bill['period']['cycle'] === 1)) {
 			$this->logWebhook(sprintf(
 				'Ignorando o evento "bill_created" para o primeiro ciclo.'), 7);
 			return true;
-		}
-
-		if (! isset($bill['subscription']['id']) || ! isset($bill['period']['cycle'])) {
-			$this->logWebhook('Pedido anterior não encontrado. Ignorando evento.', 4);
-			return false;
 		}
 
 		if (! $this->orderHandler->getOrder($bill)) {

--- a/app/code/community/Vindi/Subscription/Helper/WebhookHandler.php
+++ b/app/code/community/Vindi/Subscription/Helper/WebhookHandler.php
@@ -46,9 +46,9 @@ class Vindi_Subscription_Helper_WebhookHandler extends Mage_Core_Helper_Abstract
 			$this->logWebhook('Evento de teste do webhook.');
 			return true;
 		case 'bill_created':
-			return $this->validator->validateBillCreatedWebhook($data);
+			return $this->validator->validateBillCreatedWebhook($data['bill']);
 		case 'bill_paid':
-			return $this->validator->validateBillPaidWebhook($data);
+			return $this->validator->validateBillPaidWebhook($data['bill']);
 		case 'charge_rejected':
 			return $this->validator->validateChargeWebhook($data);
 		default:

--- a/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.7.1</version>
+            <version>1.8.0</version>
         </Vindi_Subscription>
     </modules>
     <global>


### PR DESCRIPTION
Issue: [#2255](https://github.com/vindi/recurrent/issues/2255)
## Motivação
Durante tentativas de compra via **cartão de débito**, após o pagamento capturado com sucesso e debitado do cliente, pode haver uma nova tentativa de captura rejeitada, fazendo com que o pedido seja cancelado automaticamente no Magento.
Isso acontece pois como os Webhooks são assíncronos e o Webhook de Fatura Paga (_bill_paid_) pode chegar primeiro que os demais. Nesse caso, ele entra numa fila de espera para ser reenviado.
No entanto, as demais alterações na fatura podem ser recebidas primeiro, alterando o pedido de forma _indesejada_.

## Solução Proposta
Ajustar o tratamento dos Webhooks, para que ambos sejam capazes de realizar alterações no pedido.

## Como testar
### Requisitos
- Ambiente com Magento **instalado** e **configurado** [1.7 até 1.9]
- Ngrok instalado
- Acesso as **configurações** da **Plataforma Vindi**
### Setup
- Executar o Ngrok e inserir a URL gerada nas configurações de Webhooks da Vindi
  - Deve ser substituido o prefixo da URL para a URL do Ngrok:
![image](https://user-images.githubusercontent.com/31661772/58714203-9e90c200-839a-11e9-9d08-3d760a6c2c2f.png)
- Nas configurações dos **Webhooks Vindi** habilitar os eventos:
![image](https://user-images.githubusercontent.com/31661772/58714869-11e70380-839c-11e9-8f90-45ff08d04c21.png)
### Execução
- Realizar uma compra via checkout Magento de uma assinatura (com [cartões de teste](https://atendimento.vindi.com.br/hc/pt-br/articles/208756888-Modo-Trial-quais-n%C3%BAmeros-de-cart%C3%B5es-posso-usar-para-teste-))
  - O pedido deve ser finalizado com sucesso :heavy_check_mark: 
    - Ao acessar as informações do pedido o status do mesmo deve estar como processando ('_processing_')
## 
- Desabilitar o evento *Fatura emitida*
- Realizar uma compra via checkout Magento de uma assinatura (com [cartões de teste](https://atendimento.vindi.com.br/hc/pt-br/articles/208756888-Modo-Trial-quais-n%C3%BAmeros-de-cart%C3%B5es-posso-usar-para-teste-))
  - O pedido deve ser finalizado com sucesso :heavy_check_mark: 
    - Ao acessar as informações do pedido o status do mesmo deve estar como processando ('_processing_')
## 
- Desabilitar o evento *Fatura paga*
- Habilitar o evento *Fatura emitida*
- Realizar uma compra via checkout Magento de uma assinatura (com [cartões de teste](https://atendimento.vindi.com.br/hc/pt-br/articles/208756888-Modo-Trial-quais-n%C3%BAmeros-de-cart%C3%B5es-posso-usar-para-teste-))
  - O pedido deve ser finalizado com sucesso :heavy_check_mark: 
    - Ao acessar as informações do pedido o status do mesmo deve estar como processando ('_processing_')
## 
- Realizar uma compra via checkout Magento de uma assinatura (**via Boleto**)
  - O pedido deve ficar pendente de pagamento  :warning: 
    - Ao acessar as informações do pedido o status do mesmo deve estar como pendente ('_pending_')