### PR TITLE
Alteração da visibilidade das variáveis e métodos de private para protected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [1.8.1 - 10/06/2019](https://github.com/vindi/vindi-magento/releases/tag/1.8.1)
+
+### Ajustado
+- Altera visibilidade de métodos e variáveis de `private` para `protected`
+
+
 ## [1.8.0 - 03/06/2019](https://github.com/vindi/vindi-magento/releases/tag/1.8.0)
 
 ### Ajustado

--- a/app/code/community/Vindi/Subscription/Block/Form/Cc.php
+++ b/app/code/community/Vindi/Subscription/Block/Form/Cc.php
@@ -14,7 +14,7 @@ class Vindi_Subscription_Block_Form_Cc extends Mage_Payment_Block_Form_Cc
     /**
      * @return bool
      */
-    private function isAdmin()
+    protected function isAdmin()
     {
         return Mage::app()->getStore()->isAdmin();
     }
@@ -22,7 +22,7 @@ class Vindi_Subscription_Block_Form_Cc extends Mage_Payment_Block_Form_Cc
     /**
      * @return \Mage_Customer_Model_Customer
      */
-    private function getCustomer()
+    protected function getCustomer()
     {
         if ($this->isAdmin()) {
             return Mage::getSingleton('adminhtml/session_quote')->getCustomer();
@@ -34,7 +34,7 @@ class Vindi_Subscription_Block_Form_Cc extends Mage_Payment_Block_Form_Cc
     /**
      * @return \Mage_Sales_Model_Quote
      */
-    private function getQuote()
+    protected function getQuote()
     {
         if ($this->isAdmin()) {
             return Mage::getSingleton('adminhtml/session_quote')->getQuote();
@@ -153,7 +153,7 @@ class Vindi_Subscription_Block_Form_Cc extends Mage_Payment_Block_Form_Cc
     /**
      * @return Vindi_Subscription_Helper_API
      */
-    private function api()
+    protected function api()
     {
         return Mage::helper('vindi_subscription/api');
     }

--- a/app/code/community/Vindi/Subscription/Block/Form/Dc.php
+++ b/app/code/community/Vindi/Subscription/Block/Form/Dc.php
@@ -14,7 +14,7 @@ class Vindi_Subscription_Block_Form_Dc extends Mage_Payment_Block_Form_Cc
     /**
      * @return bool
      */
-    private function isAdmin()
+    protected function isAdmin()
     {
         return Mage::app()->getStore()->isAdmin();
     }
@@ -22,7 +22,7 @@ class Vindi_Subscription_Block_Form_Dc extends Mage_Payment_Block_Form_Cc
     /**
      * @return \Mage_Customer_Model_Customer
      */
-    private function getCustomer()
+    protected function getCustomer()
     {
         if ($this->isAdmin()) {
             return Mage::getSingleton('adminhtml/session_quote')->getCustomer();
@@ -34,7 +34,7 @@ class Vindi_Subscription_Block_Form_Dc extends Mage_Payment_Block_Form_Cc
     /**
      * @return \Mage_Sales_Model_Quote
      */
-    private function getQuote()
+    protected function getQuote()
     {
         if ($this->isAdmin()) {
             return Mage::getSingleton('adminhtml/session_quote')->getQuote();
@@ -83,7 +83,7 @@ class Vindi_Subscription_Block_Form_Dc extends Mage_Payment_Block_Form_Cc
     /**
      * @return Vindi_Subscription_Helper_API
      */
-    private function api()
+    protected function api()
     {
         return Mage::helper('vindi_subscription/api');
     }

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -6,7 +6,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
     /**
      * @const string API base path.
      */
-    protected $base_path ;
+    private $base_path ;
 
     /**
      * @var string
@@ -16,7 +16,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
     /**
      * @var string
      */
-    protected $version;
+    private $version;
 
     /**
      * @var string

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -6,7 +6,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
     /**
      * @const string API base path.
      */
-    private $base_path ;
+    protected $base_path ;
 
     /**
      * @var string
@@ -16,7 +16,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
     /**
      * @var string
      */
-    private $version;
+    protected $version;
 
     /**
      * @var string
@@ -26,7 +26,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
     /**
      * @var bool
      */
-    private $acceptBankSlip;
+    protected $acceptBankSlip;
 
     public function __construct()
     {
@@ -39,7 +39,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      * @param string   $message
      * @param int|null $level
      */
-    private function log($message, $level = null)
+    protected function log($message, $level = null)
     {
         Mage::log($message, $level, 'vindi_api.log');
     }
@@ -47,7 +47,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
     /**
      * @return \Zend_Cache_Core
      */
-    private function cache()
+    protected function cache()
     {
         return Mage::app()->getCache();
     }
@@ -59,7 +59,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      *
      * @return string
      */
-    private function buildBody($data)
+    protected function buildBody($data)
     {
         $body = null;
 
@@ -76,7 +76,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      *
      * @return string
      */
-    private function getErrorMessage($error, $endpoint)
+    protected function getErrorMessage($error, $endpoint)
     {
         return "Erro em $endpoint: {$error['id']}: {$error['parameter']} - {$error['message']}";
     }
@@ -87,7 +87,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      *
      * @return bool
      */
-    private function checkResponse($response, $endpoint)
+    protected function checkResponse($response, $endpoint)
     {
         if (isset($response['errors']) && ! empty($response['errors'])) {
             foreach ($response['errors'] as $error) {
@@ -116,7 +116,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      *
      * @return array|bool|mixed
      */
-    private function request($endpoint, $method = 'POST', $data = [], $dataToLog = null)
+    protected function request($endpoint, $method = 'POST', $data = [], $dataToLog = null)
     {
         if (! $this->key) {
             return false;

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -116,7 +116,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      *
      * @return array|bool|mixed
      */
-    protected function request($endpoint, $method = 'POST', $data = [], $dataToLog = null)
+    private function request($endpoint, $method = 'POST', $data = [], $dataToLog = null)
     {
         if (! $this->key) {
             return false;

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -227,7 +227,7 @@ class Vindi_Subscription_Helper_Order
 	 *
 	 * @param Mage_Sales_Model_Quote $quote, array $vindiData, Mage_Sales_Model_Quote $shippingMethod 
 	 */
-	private function loadShipping($quote, $vindiData, $shippingMethod)
+	protected function loadShipping($quote, $vindiData, $shippingMethod)
 	{
 		// Carrega todos os métodos de entrega
 		$shippingMethods = Mage::getSingleton('vindi_subscription/config_shippingmethod')
@@ -283,7 +283,7 @@ class Vindi_Subscription_Helper_Order
 	 *
 	 * @param Mage_Sales_Model_Quote $quote, array $vindiData
 	 */
-	private function loadTaxes($quote, $vindiData)
+	protected function loadTaxes($quote, $vindiData)
 	{
 		if (isset(reset($vindiData['taxes'])['pricing_schema']['price'])
 			&& ! empty(reset($vindiData['taxes'])['pricing_schema']['price'])) {
@@ -300,7 +300,7 @@ class Vindi_Subscription_Helper_Order
 	 *
 	 * @param Mage_Sales_Model_Quote $quote, array $vindiData
 	 */
-	private function loadProducts($quote, $vindiData)
+	protected function loadProducts($quote, $vindiData)
 	{
 		foreach ($vindiData['products'] as $item) {
 			$magentoProduct = Mage::getModel('catalog/product')

--- a/app/code/community/Vindi/Subscription/Model/Observer.php
+++ b/app/code/community/Vindi/Subscription/Model/Observer.php
@@ -5,7 +5,7 @@ class Vindi_Subscription_Model_Observer
     /**
      * @var \Vindi_Subscription_Helper_Data
      */
-    private $_helper;
+    protected $_helper;
 
     /**
      * Constructor.
@@ -95,7 +95,7 @@ class Vindi_Subscription_Model_Observer
     /**
      * @param $message
      */
-    private function addNotice($message)
+    protected function addNotice($message)
     {
         Mage::getSingleton('core/session')->addNotice($message);
         Mage::app()->getFrontController()->getResponse()->setRedirect(Mage::getUrl('checkout/cart'));
@@ -107,7 +107,7 @@ class Vindi_Subscription_Model_Observer
      *
      * @return int
      */
-    private function countSubscriptions($quote)
+    protected function countSubscriptions($quote)
     {
         $count = 0;
 
@@ -125,7 +125,7 @@ class Vindi_Subscription_Model_Observer
      *
      * @return bool
      */
-    private function isSubscription($product)
+    protected function isSubscription($product)
     {
         return $product->getTypeId() === 'subscription';
     }

--- a/app/code/community/Vindi/Subscription/controllers/WebhookController.php
+++ b/app/code/community/Vindi/Subscription/controllers/WebhookController.php
@@ -37,7 +37,7 @@ class Vindi_Subscription_WebhookController extends Mage_Core_Controller_Front_Ac
 	 *
 	 * @return bool
 	 */
-	private function validateRequest()
+	protected function validateRequest()
 	{
 		$systemKey = Mage::helper('vindi_subscription')->getHashKey();
 		$requestKey = $this->getRequest()->getParam('key');

--- a/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.8.0</version>
+            <version>1.8.1</version>
         </Vindi_Subscription>
     </modules>
     <global>


### PR DESCRIPTION
## Motivação
Segue meus apontamentos:

Estou atendendo um cliente que utiliza este módulo de subscription da vindi para magento 1.

O cenário é o seguinte, o cliente possui uma regra de negócio específica que precisa realizar um override na seguinte class e method:

class > app/code/community/Vindi/Subscription/Model/Observer.php

method > validateAdminHtmlOrder

Ou seja:

class Cliente_VindiSubscription_Model_Observer extends Vindi_Subscription_Model_Observer

method validateAdminHtmlOrder chama o method $this->countSubscriptions($quote) que chama $this->isSubscription($product) que possuem visibilidade private, o que gera erro, pois uma class inherited não consegue chamar método private do pai, somente se for protected.

Ou seja, 

Tenho que alterar também a visibilidade do method countSubscriptions e isSubscription de private para protected somente para não gerar o erro.

Deparamos com o seguinte dilema, qual é a melhor prática method private ou protected?

Este artigo http://carlosschults.net/en/are-private-methods-a-code-smell/ segue meu pensamento sobre o assunto.

Minha conclusão é a seguinte: 

Este módulo de subscription da vindi para magento 1 atende muitos clientes, todo desenvolvimento do módulo é para atender uma loja default magento, propósito geral, sem regras de negócios do cliente envolvidas com o módulo, porém meu cenário mostra que clientes podem adicionar novas regras de negócio ao módulo, neste caso eu recomendo manter as variáveis e métodos ao invés de private como protected, uma vez que é um repositório público e possibilite o cliente customizar regra de negócios sobre o módulo sem causar problemas com visilidade de variáveis e métodos como private.

Espero ter sido claro com a minha explanação, podemos discutir melhor nos comentários do pull request. 

## Solução Proposta
Alteração da visibilidade das variáveis e métodos de private para protected
