### PR TITLE
Ajusta parâmetro para webhook bill_created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [1.8.4 - 19/07/2019](https://github.com/vindi/vindi-magento/releases/tag/1.8.4)
+
+### Corrigido
+- Corrige parâmetro para webhook bill_created
+
+
 ## [1.8.3 - 08/07/2019](https://github.com/vindi/vindi-magento/releases/tag/1.8.3)
 
 ### Corrigido

--- a/app/code/community/Vindi/Subscription/Helper/WebhookHandler.php
+++ b/app/code/community/Vindi/Subscription/Helper/WebhookHandler.php
@@ -46,7 +46,7 @@ class Vindi_Subscription_Helper_WebhookHandler extends Mage_Core_Helper_Abstract
 			$this->logWebhook('Evento de teste do webhook.');
 			return true;
 		case 'bill_created':
-			return $this->validator->validateBillCreatedWebhook($data['bill']);
+			return $this->validator->validateBillCreatedWebhook($data);
 		case 'bill_paid':
 			return $this->validator->validateBillPaidWebhook($data['bill']);
 		case 'charge_rejected':

--- a/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.8.3</version>
+            <version>1.8.4</version>
         </Vindi_Subscription>
     </modules>
     <global>


### PR DESCRIPTION
## Motivação
A chamada para o método `validateBillCreatedWebhook` está incorreta, fazendo com que o Webhooks de **Fatura criada** sejam ignorados pelo módulo Vindi.
Apesar do problema, não foram detectados impactos maiores justamente pelo tratamento realizado nos Webhooks de **Fatura paga** que hoje realizam as 2 funções (PR #111).

## Solução Proposta
Ajustar a chamada do método `validateBillCreatedWebhook`