### PR TITLE
Ajusta tratativa para número de parcelas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notas das versões
 
+## [1.8.6 - 01/08/2019](https://github.com/vindi/vindi-magento/releases/tag/1.8.6)
+
+### Ajustado
+- Ajusta tratativa para número de parcelas 
+
+
 ## [1.8.5 - 26/07/2019](https://github.com/vindi/vindi-magento/releases/tag/1.8.5)
 
 ### Ajustado

--- a/app/code/community/Vindi/Subscription/Model/CreditCard.php
+++ b/app/code/community/Vindi/Subscription/Model/CreditCard.php
@@ -55,7 +55,7 @@ class Vindi_Subscription_Model_CreditCard extends Vindi_Subscription_Model_Payme
 			->setCcSsStartYear($data->getCcSsStartYear())
 			->setAdditionalInformation('PaymentMethod', $this->_code)
 			->setAdditionalInformation('use_saved_cc', false)
-			->setAdditionalInformation('installments', $data->getCcInstallments());
+			->setAdditionalInformation('installments', $data->getCcInstallments() || 1);
 	}
 
 	/**

--- a/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.8.5</version>
+            <version>1.8.6</version>
         </Vindi_Subscription>
     </modules>
     <global>

--- a/tests/acceptance/vindiCheckoutWithCreditCardCest.php
+++ b/tests/acceptance/vindiCheckoutWithCreditCardCest.php
@@ -9,7 +9,7 @@ class VindiCheckoutWithCreditCardCest
             $I->setConnectionConfig($I);
     }
 
-    public function buyAnProductInInstallment(AcceptanceTester $I)
+    public function buyAProductInInstallment(AcceptanceTester $I)
     {
         $I->setDefaultCreditCard($I, true);
         $I->loginAsUser($I);
@@ -33,7 +33,7 @@ class VindiCheckoutWithCreditCardCest
         $I->see('Your order has been received.');
     }
 
-    public function buyAnProductWithoutInstallment(AcceptanceTester $I)
+    public function buyAProductWithoutInstallment(AcceptanceTester $I)
     {
         $I->setDefaultCreditCard($I, false);
         $I->loginAsUser($I);
@@ -56,8 +56,32 @@ class VindiCheckoutWithCreditCardCest
         $I->seeInCurrentUrl('/checkout/onepage/success');
         $I->see('Your order has been received.');
     }
+    public function buyAProductWithInstallmentsOne(AcceptanceTester $I)
+    {
+        $I->setDefaultCreditCard($I, false, 1);
+        $I->loginAsUser($I);
+        $I->addProductToCart($I);
+        $I->click('Proceed to Checkout');
+        $I->skipCheckoutForm($I);
+        $I->waitForElement('#dt_method_vindi_creditcard', 30);
+        $I->selectOption('dl#checkout-payment-method-load', 'Cartão de Crédito');
+        $I->dontSeeElement('select.required-entry');
 
-    public function buyAnProductWithDiscount(AcceptanceTester $I)
+        try
+        {
+            $I->fillCreditCardInfo($I);
+        } catch(Exception $e) { }
+
+        $I->click('Continue', '#payment-buttons-container');
+        $I->waitForElement('#review-buttons-container', 30);
+        $I->click('Place Order');
+        $I->waitForElement('.main-container.col1-layout', 30);
+        $I->seeInCurrentUrl('/checkout/onepage/success');
+        $I->see('Your order has been received.');
+    }
+
+
+    public function buyAProductWithDiscount(AcceptanceTester $I)
     {
         $I->setDefaultCreditCard($I, false);
         $I->loginAsUser($I);


### PR DESCRIPTION
## Motivação
Ao ativar o parcelamento e configurar o número máximo de parcelas como 1, ao tentar realizar a compra, há o retorno para informar o número de parcelas, mesmo não tendo o campo para informar as parcelas.

-Configuração do método de pagamento:
![image](https://user-images.githubusercontent.com/50752906/62077733-37b84980-b221-11e9-9abb-2a46748e79d0.png)

-Erro apresentado no checkout:
![image](https://user-images.githubusercontent.com/50752906/62077952-c4630780-b221-11e9-8349-b6fcc90527eb.png)


## Solução proposta
Tratativa para setar como "1" quando o número de parcelas não for informado no checkout.
