### PR TITLE
Ajusta fluxo de assinaturas com cobrança no término do período

### DIFF
--- a/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
+++ b/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
@@ -369,7 +369,9 @@ trait Vindi_Subscription_Trait_PaymentProcessor
 		$type = 'bills';
 		if($payment && $payment['id']) {
 			$vindiId = $payment['id'];
+			$billing_type = 'beginning_of_period';
 			if (! $this->isSingleOrder($order)) {
+				$billing_type = $payment['billing_trigger_type'];
 				$payment = $payment['bill'];
 				$type = 'subscriptions';
 			}
@@ -377,6 +379,7 @@ trait Vindi_Subscription_Trait_PaymentProcessor
 			$paymentMethod = reset($payment['charges'])['payment_method']['type'];
 			if ($paymentMethod === 'PaymentMethod::BankSlip'
 				|| $paymentMethod === 'PaymentMethod::DebitCard'
+				|| $billing_type !== 'beginning_of_period'
 				|| $payment['status'] === 'paid'
 				|| $payment['status'] === 'review'
 				|| reset($payment['charges'])['status'] === 'fraud_review')

--- a/tests/_support/Shop.php
+++ b/tests/_support/Shop.php
@@ -8,6 +8,12 @@ trait Shop
         $I->click('Add to Cart');
     }
 
+    public function addSubscriptionToCart($I)
+    {
+        $I->amOnPage('/vindi-subscription.html');
+        $I->click('Add to Cart');
+    }
+
     public function addDiscountCode($I)
     {
         $I->fillField('#coupon_code', 'desconto');

--- a/tests/acceptance/vindiCheckoutWithBankSlipCest.php
+++ b/tests/acceptance/vindiCheckoutWithBankSlipCest.php
@@ -46,4 +46,21 @@ class VindiCheckoutWithBankSlipCest
         if ($bill['amount'] != '14.8')
             throw new \RuntimeException;
     }
+
+    public function buyAnSubscription(AcceptanceTester $I)
+    {
+        $I->setDefaultBankSlip($I);
+        $I->loginAsUser($I);
+        $I->addSubscriptionToCart($I);
+        $I->click('Proceed to Checkout');
+        $I->skipCheckoutForm($I);
+        $I->waitForElement('#dt_method_vindi_bankslip', 30);
+        $I->selectOption('dl#checkout-payment-method-load', 'Boleto Bancário');
+        $I->click('Continue', '#payment-buttons-container');
+        $I->waitForElement('#review-buttons-container', 30);
+        $I->click('Place Order');
+        $I->waitForElement('.main-container.col1-layout', 30);
+        $I->seeInCurrentUrl('/checkout/onepage/success');
+        $I->see('Your order has been received.');
+    }
 }

--- a/tests/acceptance/vindiCheckoutWithCreditCardCest.php
+++ b/tests/acceptance/vindiCheckoutWithCreditCardCest.php
@@ -83,4 +83,28 @@ class VindiCheckoutWithCreditCardCest
         if ($bill['amount'] != '14.8')
             throw new \RuntimeException;
     }
+
+    public function buyAnSubscriptionInInstallment(AcceptanceTester $I)
+    {
+        $I->setDefaultCreditCard($I, true);
+        $I->loginAsUser($I);
+        $I->addSubscriptionToCart($I);
+        $I->click('Proceed to Checkout');
+        $I->skipCheckoutForm($I);
+        $I->waitForElement('#dt_method_vindi_creditcard', 30);
+        $I->selectOption('dl#checkout-payment-method-load', 'Cartão de Crédito');
+        $I->waitForElement('#vindi_cc_installments', 30);
+
+        try
+        {
+            $I->fillCreditCardInfo($I, 2);
+        } catch(Exception $e) { }
+
+        $I->click('Continue', '#payment-buttons-container');
+        $I->waitForElement('#review-buttons-container', 30);
+        $I->click('Place Order');
+        $I->waitForElement('.main-container.col1-layout', 30);
+        $I->seeInCurrentUrl('/checkout/onepage/success');
+        $I->see('Your order has been received.');
+    }
 }


### PR DESCRIPTION
resolve [#2512](https://github.com/vindi/recurrent/issues/2512)

## Motivação
Quando o comprador tenta realizar uma compra de uma assinatura com cobrança exatamente no término do período, ocorre um erro no checkout.
Isso se dá pois a validação é realizada no status de retorno da cobrança. Porém, em caso de cobranças agendadas o débito não é gerada automaticamente.

## Solução Proposta
Validar o tipo de assinatura de cobrança da assinatura, para permitir que o pedido seja criado _aguardando pagamento_.
Posteriormente ao recebimento do _webhook_ de "fatura paga", o pedido será atualizado.