### PR TITLE
Ajusta tratativa para número de parcelas em cartões de crédito salvos

### DIFF
--- a/app/code/community/Vindi/Subscription/Model/CreditCard.php
+++ b/app/code/community/Vindi/Subscription/Model/CreditCard.php
@@ -37,7 +37,7 @@ class Vindi_Subscription_Model_CreditCard extends Vindi_Subscription_Model_Payme
 		if ('saved' === $data->getCcChoice()) {
 			$info->setAdditionalInformation('PaymentMethod', $this->_code)
 				->setAdditionalInformation('use_saved_cc', true)
-				->setAdditionalInformation('installments', $data->getCcInstallments());
+				->setAdditionalInformation('installments', $data->getCcInstallments() || 1);
 
 			return $this;
 		}
@@ -68,7 +68,7 @@ class Vindi_Subscription_Model_CreditCard extends Vindi_Subscription_Model_Payme
 		$verifyStatus = $this->api()->verifyCustomerPaymentProfile($paymentProfileId);
 		return ($verifyStatus['transaction']['status'] === 'success');
 	}
-	
+
 	/**
 	 * @param int $customerVindiId
 	 */
@@ -118,7 +118,7 @@ class Vindi_Subscription_Model_CreditCard extends Vindi_Subscription_Model_Payme
 				return 'Você deve informar o número de parcelas.';
 			}
 
-			if ($installments != 1) { 
+			if ($installments != 1) {
 				$maxInstallmentNumber = Mage::getStoreConfig('payment/vindi_creditcard/max_installments_number');
 
 				if ($installments > $maxInstallmentNumber) {

--- a/app/code/community/Vindi/Subscription/Model/CreditCard.php
+++ b/app/code/community/Vindi/Subscription/Model/CreditCard.php
@@ -37,7 +37,7 @@ class Vindi_Subscription_Model_CreditCard extends Vindi_Subscription_Model_Payme
 		if ('saved' === $data->getCcChoice()) {
 			$info->setAdditionalInformation('PaymentMethod', $this->_code)
 				->setAdditionalInformation('use_saved_cc', true)
-				->setAdditionalInformation('installments', $data->getCcInstallments() || 1);
+				->setAdditionalInformation('installments', $data->getCcInstallments() ?: 1);
 
 			return $this;
 		}
@@ -55,7 +55,7 @@ class Vindi_Subscription_Model_CreditCard extends Vindi_Subscription_Model_Payme
 			->setCcSsStartYear($data->getCcSsStartYear())
 			->setAdditionalInformation('PaymentMethod', $this->_code)
 			->setAdditionalInformation('use_saved_cc', false)
-			->setAdditionalInformation('installments', $data->getCcInstallments() || 1);
+			->setAdditionalInformation('installments', $data->getCcInstallments() ?: 1);
 	}
 
 	/**

--- a/tests/acceptance/vindiCheckoutWithCreditCardCest.php
+++ b/tests/acceptance/vindiCheckoutWithCreditCardCest.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 class VindiCheckoutWithCreditCardCest
 {
@@ -122,6 +122,23 @@ class VindiCheckoutWithCreditCardCest
     public function buySubscriptionWithoutInstallment(AcceptanceTester $I)
     {
         $I->setDefaultCreditCard($I, false);
+        $I->loginAsUser($I);
+        $I->addSubscriptionToCart($I);
+        $I->click('Proceed to Checkout');
+        $I->skipCheckoutForm($I);
+        $I->waitForElement('#dt_method_vindi_creditcard', 30);
+        $I->selectOption('dl#checkout-payment-method-load', 'Cartão de Crédito');
+        $I->click('Continue', '#payment-buttons-container');
+        $I->waitForElement('#review-buttons-container', 30);
+        $I->click('Place Order');
+        $I->waitForElement('.main-container.col1-layout', 30);
+        $I->seeInCurrentUrl('/checkout/onepage/success');
+        $I->see('Your order has been received.');
+    }
+
+    public function buyProductInInstallmentsOneWithSavedCreditCard(AcceptanceTester $I)
+    {
+        $I->setDefaultCreditCard($I, true, 1);
         $I->loginAsUser($I);
         $I->addSubscriptionToCart($I);
         $I->click('Proceed to Checkout');

--- a/tests/acceptance/vindiCheckoutWithCreditCardCest.php
+++ b/tests/acceptance/vindiCheckoutWithCreditCardCest.php
@@ -11,6 +11,7 @@ class VindiCheckoutWithCreditCardCest
 
     public function buyProductInInstallment(AcceptanceTester $I)
     {
+        $installments = 2;
         $I->setDefaultCreditCard($I, true);
         $I->loginAsUser($I);
         $I->addProductToCart($I);
@@ -22,7 +23,7 @@ class VindiCheckoutWithCreditCardCest
 
         try
         {
-            $I->fillCreditCardInfo($I, 2);
+            $I->fillCreditCardInfo($I, $installments);
         } catch(Exception $e) { }
 
         $I->click('Continue', '#payment-buttons-container');
@@ -31,6 +32,10 @@ class VindiCheckoutWithCreditCardCest
         $I->waitForElement('.main-container.col1-layout', 30);
         $I->seeInCurrentUrl('/checkout/onepage/success');
         $I->see('Your order has been received.');
+
+        $bill = $I->getLastVindiBill();
+        if ($bill['installments'] != $installments)
+            throw new \RuntimeException;
     }
 
     public function buyProductWithoutInstallment(AcceptanceTester $I)
@@ -55,11 +60,16 @@ class VindiCheckoutWithCreditCardCest
         $I->waitForElement('.main-container.col1-layout', 30);
         $I->seeInCurrentUrl('/checkout/onepage/success');
         $I->see('Your order has been received.');
+
+        $bill = $I->getLastVindiBill();
+        if ($bill['installments'] != 1)
+            throw new \RuntimeException;
     }
 
-    public function buyAProductWithInstallmentsOne(AcceptanceTester $I)
+    public function buyAProductWithInstallmentsOneEnabled(AcceptanceTester $I)
     {
-        $I->setDefaultCreditCard($I, false, 1);
+        $installments = 1;
+        $I->setDefaultCreditCard($I, false, $installments);
         $I->loginAsUser($I);
         $I->addProductToCart($I);
         $I->click('Proceed to Checkout');
@@ -73,6 +83,10 @@ class VindiCheckoutWithCreditCardCest
         $I->waitForElement('.main-container.col1-layout', 30);
         $I->seeInCurrentUrl('/checkout/onepage/success');
         $I->see('Your order has been received.');
+
+        $bill = $I->getLastVindiBill();
+        if ($bill['installments'] != $installments)
+            throw new \RuntimeException;
     }
 
     public function buyProductWithDiscount(AcceptanceTester $I)
@@ -97,12 +111,13 @@ class VindiCheckoutWithCreditCardCest
         $I->click('Place Order');
         $I->waitForElement('.main-container.col1-layout', 30);
         $I->seeInCurrentUrl('/checkout/onepage/success');
+
         $bill = $I->getLastVindiBill();
         if ($bill['amount'] != '14.8')
             throw new \RuntimeException;
     }
 
-    public function buyMonthlySubscriptionWithInstallments(AcceptanceTester $I)
+    public function buyMonthlySubscriptionWithEnabledInstallments(AcceptanceTester $I)
     {
         $I->setDefaultCreditCard($I, true);
         $I->loginAsUser($I);
@@ -117,6 +132,10 @@ class VindiCheckoutWithCreditCardCest
         $I->waitForElement('.main-container.col1-layout', 30);
         $I->seeInCurrentUrl('/checkout/onepage/success');
         $I->see('Your order has been received.');
+
+        $bill = $I->getLastVindiBill();
+        if ($bill['installments'] != 1)
+            throw new \RuntimeException;
     }
 
     public function buySubscriptionWithoutInstallment(AcceptanceTester $I)
@@ -134,11 +153,16 @@ class VindiCheckoutWithCreditCardCest
         $I->waitForElement('.main-container.col1-layout', 30);
         $I->seeInCurrentUrl('/checkout/onepage/success');
         $I->see('Your order has been received.');
+
+        $bill = $I->getLastVindiBill();
+        if ($bill['installments'] != 1)
+            throw new \RuntimeException;
     }
 
     public function buyProductInInstallmentsOneWithSavedCreditCard(AcceptanceTester $I)
     {
-        $I->setDefaultCreditCard($I, true, 1);
+        $installments = 1;
+        $I->setDefaultCreditCard($I, true, $installments);
         $I->loginAsUser($I);
         $I->addSubscriptionToCart($I);
         $I->click('Proceed to Checkout');
@@ -151,5 +175,9 @@ class VindiCheckoutWithCreditCardCest
         $I->waitForElement('.main-container.col1-layout', 30);
         $I->seeInCurrentUrl('/checkout/onepage/success');
         $I->see('Your order has been received.');
+
+        $bill = $I->getLastVindiBill();
+        if ($bill['installments'] != $installments)
+            throw new \RuntimeException;
     }
 }


### PR DESCRIPTION
## Motivação
O PR #119 tratava o parcelamento para cartões de crédito, na primeira compra. Esse PR trata agora o parcelamento para cartões salvos no checkout.

## Solução Proposta
Tratativa para setar como "1" quando o número de parcelas não for informado no checkout com o cartão de crédito salvo.