### PR TITLE
Adiciona suporte para boletos Webservice

### DIFF
--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -179,13 +179,8 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      */
     public function createCustomerPaymentProfile($body)
     {
-        // Protect credit card number.
-        $dataToLog = $body;
-        $dataToLog['card_number'] = '**** *' . substr($dataToLog['card_number'], -3);
-        $dataToLog['card_cvv'] = '***';
-
-         $this->log(json_encode($dataToLog), 'vindi_creditcard.log');
-         $customerId = $body['customer_id'];
+        $this->log(json_encode($dataToLog), 'vindi_creditcard.log');
+        $customerId = $body['customer_id'];
         $this->cache()->remove("vindi_payment_profile_{$customerId}");
 
         return $this->connector->post('payment_profiles', $body);

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -27,43 +27,6 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
         return Mage::app()->getCache();
     }
 
-
-    /**
-     * @param array $error
-     * @param       $endpoint
-     *
-     * @return string
-     */
-    protected function getErrorMessage($error, $endpoint)
-    {
-        return "Erro em $endpoint: {$error['id']}: {$error['parameter']} - {$error['message']}";
-    }
-
-    /**
-     * @param array $response
-     * @param       $endpoint
-     *
-     * @return bool
-     */
-    protected function checkResponse($response, $endpoint)
-    {
-        if (isset($response['errors']) && ! empty($response['errors'])) {
-            foreach ($response['errors'] as $error) {
-                $message = $this->getErrorMessage($error, $endpoint);
-
-                Mage::getSingleton('core/session')->addError($message);
-
-                $this->lastError = $message;
-            }
-
-            return false;
-        }
-
-        $this->lastError = '';
-
-        return true;
-    }
-
     /**
      * Perform request to API.
      *

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -173,7 +173,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
         $customerId = $this->cache()->load("vindi_customer_by_code_{$code}");
 
         if ($customerId === false) {
-            $response = $this->connector->get("customers/search?code={$code}", 'GET');
+            $response = $this->connector->get("customers/search?code={$code}");
 
             if ($response && (1 === count($response['customers'])) && isset($response['customers'][0]['id'])) {
                 $customerId = $response['customers'][0]['id'];
@@ -221,10 +221,11 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
         $dataToLog['card_number'] = '**** *' . substr($dataToLog['card_number'], -3);
         $dataToLog['card_cvv'] = '***';
 
-        $customerId = $body['customer_id'];
+         $this->log(json_encode($dataToLog), 'vindi_creditcard.log');
+         $customerId = $body['customer_id'];
         $this->cache()->remove("vindi_payment_profile_{$customerId}");
 
-        return $this->connector->post('payment_profiles', 'POST', $body, $dataToLog);
+        return $this->connector->post('payment_profiles', $body);
     }
 
     /**
@@ -236,7 +237,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      */
     public function verifyCustomerPaymentProfile($id)
     {
-        return $this->connector->post('payment_profiles/' . $id . '/verify', 'POST');
+        return $this->connector->post('payment_profiles/' . $id . '/verify');
     }
 
     /**
@@ -258,7 +259,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
             $endpoint = 'payment_profiles?query=customer_id%3D' . $customerId
                 . '%20status%3Dactive%20type%3DPaymentProfile%3A%3A'. $type;
 
-            $response = $this->connector->get($endpoint, 'GET');
+            $response = $this->connector->get($endpoint);
 
             if ($response && $response['payment_profiles'] && count($response['payment_profiles'])) {
                 $paymentProfile = $response['payment_profiles'][0];
@@ -284,7 +285,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      */
     public function createSubscription($body)
     {
-        if (($response = $this->connector->post('subscriptions', 'POST', $body)) && isset($response['subscription']['id'])) {
+        if (($response = $this->connector->post('subscriptions', $body)) && isset($response['subscription']['id'])) {
 
             $subscription = $response['subscription'];
             $subscription['bill'] = $response['bill'];
@@ -312,7 +313,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
                 'bank_slip'   => false,
             ];
 
-            $response = $this->connector->get('payment_methods', 'GET');
+            $response = $this->connector->get('payment_methods');
 
             if (false === $response) {
                 return $this->acceptBankSlip = false;
@@ -402,7 +403,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      */
     public function createBill($body)
     {
-        if ($response = $this->connector->post('bills', 'POST', $body)) {
+        if ($response = $this->connector->post('bills', $body)) {
             return $response['bill'];
         }
 
@@ -416,7 +417,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      */
     public function approveBill($billId)
     {
-        $response = $this->connector->get("bills/{$billId}", 'GET');
+        $response = $this->connector->get("bills/{$billId}");
 
         if (false === $response || ! isset($response['bill'])) {
             return false;
@@ -428,7 +429,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
             return true;
         }
 
-        return $this->connector->post("bills/{$billId}/approve", 'POST');
+        return $this->connector->post("bills/{$billId}/approve");
     }
 
     /**
@@ -438,7 +439,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      */
     public function cancelPurchase($vindiId, $type)
     {
-        $this->connector->delete("{$type}/{$vindiId}", 'DELETE');
+        $this->connector->delete("{$type}/{$vindiId}");
     }
 
     /**
@@ -448,7 +449,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      */
     public function getBankSlipDownload($billId)
     {
-        $response = $this->connector->get("bills/{$billId}", 'GET');
+        $response = $this->connector->get("bills/{$billId}");
 
         if (false === $response) {
             return false;
@@ -463,7 +464,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
     public function getProducts()
     {
         $list = [];
-        $response = $this->connector->get('products?query=status:active', 'GET');
+        $response = $this->connector->get('products?query=status:active');
 
         if ($products = $response['products']) {
             foreach ($products as $product) {

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -116,7 +116,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      *
      * @return array|bool|mixed
      */
-    private function request($endpoint, $method = 'POST', $data = [], $dataToLog = null)
+    public function request($endpoint, $method = 'POST', $data = [], $dataToLog = null)
     {
         if (! $this->key) {
             return false;
@@ -271,7 +271,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
     /**
      * Make an API request to verify a Payment Profile to a Customer.
      *
-     * @param $id integer 
+     * @param $id integer
      *
      * @return array|bool|mixed
      */
@@ -358,7 +358,6 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
             if (false === $response) {
                 return $this->acceptBankSlip = false;
             }
-
             foreach ($response['payment_methods'] as $method) {
                 if ('active' !== $method['status']) {
                     continue;
@@ -374,7 +373,8 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
                         $paymentMethods['debit_card'],
                         $method['payment_companies']
                     );
-                } elseif ('PaymentMethod::BankSlip' === $method['type']) {
+                } elseif ('PaymentMethod::BankSlip' === $method['type'] ||
+                          'PaymentMethod::OnlineBankSlip' === $method['type']) {
                     $paymentMethods['bank_slip'] = true;
                 }
             }
@@ -733,7 +733,7 @@ class Vindi_Subscription_Helper_API extends Mage_Core_Helper_Abstract
      * @return array|bool|mixed
      */
     public function findOrCreateUniquePaymentProduct($order)
-    {      
+    {
         $billItems = array();
         foreach ($order->getItemsCollection() as $item) {
             $productId = $this->findOrCreateProduct(

--- a/app/code/community/Vindi/Subscription/Helper/Connector.php
+++ b/app/code/community/Vindi/Subscription/Helper/Connector.php
@@ -2,6 +2,7 @@
 
 class Vindi_Subscription_Helper_Connector
 {
+
     use Vindi_Subscription_Trait_LogMessenger;
 
     public function post($endpoint, $body)
@@ -22,6 +23,31 @@ class Vindi_Subscription_Helper_Connector
     public function delete($endpoint, $body)
     {
        $this->request($endpoint, $body, 'DELETE');
+    }
+
+    /**
+     * @param array $response
+     * @param       $endpoint
+     *
+     * @return bool
+     */
+    protected function checkResponse($response, $endpoint)
+    {
+        if (isset($response['errors']) && ! empty($response['errors'])) {
+            foreach ($response['errors'] as $error) {
+                $message = $this->getErrorMessage($error, $endpoint);
+
+                Mage::getSingleton('core/session')->addError($message);
+
+                $this->lastError = $message;
+            }
+
+            return false;
+        }
+
+        $this->lastError = '';
+
+        return true;
     }
 
     private function request($endpoint, $method = 'POST', $data = [])
@@ -131,4 +157,15 @@ class Vindi_Subscription_Helper_Connector
         return $body;
     }
 
+
+        /**
+         * @param array $error
+         * @param       $endpoint
+         *
+         * @return string
+         */
+    protected function getErrorMessage($error, $endpoint)
+    {
+        return "Erro em $endpoint: {$error['id']}: {$error['parameter']} - {$error['message']}";
+    }
 }

--- a/app/code/community/Vindi/Subscription/Helper/Connector.php
+++ b/app/code/community/Vindi/Subscription/Helper/Connector.php
@@ -24,7 +24,7 @@ class Vindi_Subscription_Helper_Connector
        $this->request($endpoint, $body, 'DELETE');
     }
 
-    private function request($endpoint, $method = 'POST', $data = [], $dataToLog = null)
+    private function request($endpoint, $method = 'POST', $data = [])
     {
         $key = Mage::helper('vindi_subscription')->getKey();
         if (! $key) {
@@ -36,7 +36,7 @@ class Vindi_Subscription_Helper_Connector
 
         $requestId = rand();
 
-        $dataToLog = null !== $dataToLog ? $this->buildBody($dataToLog) : $body;
+        $dataToLog = $this->encrypt($body, $endpoint);
 
         $this->log(sprintf("[Request #%s]: Novo Request para a API.\n%s %s\n%s", $requestId, $method, $url,
             $dataToLog), 'vindi_api.log');
@@ -94,6 +94,23 @@ class Vindi_Subscription_Helper_Connector
         }
 
         return $responseBody;
+    }
+
+    /**
+     * Remove sensitive content.
+     *
+     * @param array $body | string $endpoint
+     *
+     * @return array
+     */
+    private function encrypt ($body , $endpoint)
+    {
+        if ('payment_profile' === $endpoint) {
+            $dataToLog = $body;
+            $dataToLog['card_number'] = '**** *' . substr($dataToLog['card_number'], -3);
+            $dataToLog['card_cvv'] = '***';
+            return $dataToLog;
+        }
     }
 
     /**

--- a/app/code/community/Vindi/Subscription/Helper/Connector.php
+++ b/app/code/community/Vindi/Subscription/Helper/Connector.php
@@ -5,22 +5,22 @@ class Vindi_Subscription_Helper_Connector
 
     use Vindi_Subscription_Trait_LogMessenger;
 
-    public function post($endpoint, $body)
+    public function post($endpoint, $body = [])
     {
        $this->request($endpoint, $body, 'POST');
     }
 
-    public function get($endpoint, $body)
+    public function get($endpoint, $body = [])
     {
        $this->request($endpoint, $body, 'GET');
     }
 
-    public function put($endpoint, $body)
+    public function put($endpoint, $body = [])
     {
        $this->request($endpoint, $body, 'PUT');
     }
 
-    public function delete($endpoint, $body)
+    public function delete($endpoint, $body = [])
     {
        $this->request($endpoint, $body, 'DELETE');
     }
@@ -84,7 +84,7 @@ class Vindi_Subscription_Helper_Connector
             CURLOPT_CUSTOMREQUEST  => $method
         ];
 
-        if (!empty($body)) {
+        if (! empty($body)) {
             $ch_options[CURLOPT_POSTFIELDS] = $body;
         }
 

--- a/app/code/community/Vindi/Subscription/Helper/Connector.php
+++ b/app/code/community/Vindi/Subscription/Helper/Connector.php
@@ -7,22 +7,22 @@ class Vindi_Subscription_Helper_Connector
 
     public function post($endpoint, $body = [])
     {
-       $this->request($endpoint, $body, 'POST');
+       return $this->request($endpoint, $body, 'POST');
     }
 
     public function get($endpoint, $body = [])
     {
-       $this->request($endpoint, $body, 'GET');
+       return $this->request($endpoint, $body, 'GET');
     }
 
     public function put($endpoint, $body = [])
     {
-       $this->request($endpoint, $body, 'PUT');
+       return $this->request($endpoint, $body, 'PUT');
     }
 
     public function delete($endpoint, $body = [])
     {
-       $this->request($endpoint, $body, 'DELETE');
+       return $this->request($endpoint, $body, 'DELETE');
     }
 
     /**
@@ -50,7 +50,7 @@ class Vindi_Subscription_Helper_Connector
         return true;
     }
 
-    private function request($endpoint, $method = 'POST', $data = [])
+    private function request($endpoint, $data = [], $method = 'POST')
     {
         $key = Mage::helper('vindi_subscription')->getKey();
         if (! $key) {

--- a/app/code/community/Vindi/Subscription/Helper/Connector.php
+++ b/app/code/community/Vindi/Subscription/Helper/Connector.php
@@ -1,0 +1,117 @@
+<?php
+
+class Vindi_Subscription_Helper_Connector
+{
+    use Vindi_Subscription_Trait_LogMessenger;
+
+    public function post($endpoint, $body)
+    {
+       $this->request($endpoint, $body, 'POST');
+    }
+
+    public function get($endpoint, $body)
+    {
+       $this->request($endpoint, $body, 'GET');
+    }
+
+    public function put($endpoint, $body)
+    {
+       $this->request($endpoint, $body, 'PUT');
+    }
+
+    public function delete($endpoint, $body)
+    {
+       $this->request($endpoint, $body, 'DELETE');
+    }
+
+    private function request($endpoint, $method = 'POST', $data = [], $dataToLog = null)
+    {
+        $key = Mage::helper('vindi_subscription')->getKey();
+        if (! $key) {
+            return false;
+        }
+
+        $url = Mage::getStoreConfig('vindi_subscription/general/sandbox_mode') . $endpoint;
+        $body = $this->buildBody($data);
+
+        $requestId = rand();
+
+        $dataToLog = null !== $dataToLog ? $this->buildBody($dataToLog) : $body;
+
+        $this->log(sprintf("[Request #%s]: Novo Request para a API.\n%s %s\n%s", $requestId, $method, $url,
+            $dataToLog), 'vindi_api.log');
+
+        $ch = curl_init();
+        $ch_options = [
+            CURLOPT_HTTPHEADER => [
+                'Content-Type: application/json',
+            ],
+            CURLOPT_TIMEOUT        => 60,
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_HEADER         => true,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_USERAGENT      => 'Vindi-Magento/' .
+                (string) Mage::getConfig()->getModuleConfig('Vindi_Subscription')->version,
+            CURLOPT_SSLVERSION     => 'CURL_SSLVERSION_TLSv1_2',
+            CURLOPT_USERPWD        => $key . ':',
+            CURLOPT_URL            => $url,
+            CURLOPT_CUSTOMREQUEST  => $method
+        ];
+
+        if (!empty($body)) {
+            $ch_options[CURLOPT_POSTFIELDS] = $body;
+        }
+
+        curl_setopt_array($ch, $ch_options);
+
+        $response = curl_exec($ch);
+
+        $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $body = substr($response, curl_getinfo($ch, CURLINFO_HEADER_SIZE));
+
+        if (curl_errno($ch) || $response === false) {
+            $this->log(sprintf("[Request #%s]: Erro ao fazer request!\n%s", $requestId, print_r($response, true)));
+
+            return false;
+        }
+
+        curl_close($ch);
+
+        $status = "HTTP Status: $statusCode";
+        $this->log(sprintf("[Request #%s]: Nova Resposta da API.\n%s\n%s", $requestId, $status, $body));
+
+        $responseBody = json_decode($body, true);
+
+        if (! $responseBody) {
+            $this->log(sprintf('[Request #%s]: Erro ao recuperar corpo do request! %s', $requestId,
+                print_r($body, true)));
+
+            return false;
+        }
+
+        if (! $this->checkResponse($responseBody, $endpoint)) {
+            return false;
+        }
+
+        return $responseBody;
+    }
+
+    /**
+     * Build HTTP Query.
+     *
+     * @param array $data
+     *
+     * @return string
+     */
+    private function buildBody($data)
+    {
+        $body = null;
+
+        if(!empty($data)) {
+            $body = json_encode($data);
+        }
+
+        return $body;
+    }
+
+}

--- a/app/code/community/Vindi/Subscription/Helper/Connector.php
+++ b/app/code/community/Vindi/Subscription/Helper/Connector.php
@@ -110,7 +110,7 @@ class Vindi_Subscription_Helper_Connector
 
         if (! $responseBody) {
             $this->log(sprintf('[Request #%s]: Erro ao recuperar corpo do request! %s', $requestId,
-                print_r($body, true)));
+                print_r($body, true)), 'vindi_api.log');
 
             return false;
         }

--- a/app/code/community/Vindi/Subscription/Helper/Connector.php
+++ b/app/code/community/Vindi/Subscription/Helper/Connector.php
@@ -129,7 +129,7 @@ class Vindi_Subscription_Helper_Connector
      *
      * @return array
      */
-    private function encrypt ($body , $endpoint)
+    private function encrypt ($body, $endpoint)
     {
         if ('payment_profile' === $endpoint) {
             $dataToLog = $body;

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -2,8 +2,8 @@
 
 class Vindi_Subscription_Helper_Order
 {
-	use Vindi_Subscription_Trait_LogMessenger; 
-	
+	use Vindi_Subscription_Trait_LogMessenger;
+
 	/**
 	 * Altera o status de um pedido para Cancelado
 	 *
@@ -193,7 +193,7 @@ class Vindi_Subscription_Helper_Order
 
 	/*
 	 * Atualiza o pedido inserindo as informações refentes a renovação de assinatura Vindi
-	 * 
+	 *
 	 * @param Mage_Sales_Model_Order $order, array $vindiData
 	 *
 	 * @return bool
@@ -201,7 +201,7 @@ class Vindi_Subscription_Helper_Order
 	public function renewalOrder($order, $vindiData)
 	{
 		$order->setVindiSubscriptionId($vindiData['bill']['subscription']);
-		$order->setVindiBillId($vindiData['bill']['id']);	
+		$order->setVindiBillId($vindiData['bill']['id']);
 		$order->setVindiSubscriptionPeriod($vindiData['bill']['cycle']);
 		$order->setBaseGrandTotal($vindiData['bill']['amount']);
 		$order->setGrandTotal($vindiData['bill']['amount']);
@@ -210,7 +210,8 @@ class Vindi_Subscription_Helper_Order
 		if (Mage::getStoreConfig('vindi_subscription/general/bankslip_link_in_order_comment')) {
 			$charges = $vindiData['bill']['charges'];
 			foreach ($charges as $charge) {
-				if ($charge['payment_method']['type'] == 'PaymentMethod::BankSlip') {
+				if ($charge['payment_method']['type'] == 'PaymentMethod::BankSlip' ||
+                    $charge['payment_method']['type'] == 'PaymentMethod::OnlineBankSlip') {
 					$order->addStatusHistoryComment(sprintf(
 						'<a target="_blank" href="%s">Clique aqui</a> para visualizar o boleto.',
 						$charge['print_url']
@@ -226,7 +227,7 @@ class Vindi_Subscription_Helper_Order
 	/*
 	 * Carrega os dados e valores referentes ao Frete do pedido
 	 *
-	 * @param Mage_Sales_Model_Quote $quote, array $vindiData, Mage_Sales_Model_Quote $shippingMethod 
+	 * @param Mage_Sales_Model_Quote $quote, array $vindiData, Mage_Sales_Model_Quote $shippingMethod
 	 */
 	protected function loadShipping($quote, $vindiData, $shippingMethod)
 	{
@@ -316,8 +317,8 @@ class Vindi_Subscription_Helper_Order
 			if (number_format($magentoProduct->getPrice(), 2)
 				!== number_format($item['pricing_schema']['price'], 2)) {
 
-				$this->logWebhook(sprintf("Divergencia de valores na fatura #%s:  " . 
-					"produto %s: ID Magento #%s , ID Vindi #%s: " . 
+				$this->logWebhook(sprintf("Divergencia de valores na fatura #%s:  " .
+					"produto %s: ID Magento #%s , ID Vindi #%s: " .
 					"Valor Magento R$ %s , Valor Vindi R$ %s",
 					$vindiData['bill']['id'],
 					$magentoProduct->getName(),

--- a/app/code/community/Vindi/Subscription/Helper/Order.php
+++ b/app/code/community/Vindi/Subscription/Helper/Order.php
@@ -210,8 +210,8 @@ class Vindi_Subscription_Helper_Order
 		if (Mage::getStoreConfig('vindi_subscription/general/bankslip_link_in_order_comment')) {
 			$charges = $vindiData['bill']['charges'];
 			foreach ($charges as $charge) {
-				if ($charge['payment_method']['type'] == 'PaymentMethod::BankSlip' ||
-                    $charge['payment_method']['type'] == 'PaymentMethod::OnlineBankSlip') {
+				if ($charge['payment_method']['type'] === 'PaymentMethod::BankSlip' ||
+                    $charge['payment_method']['type'] === 'PaymentMethod::OnlineBankSlip') {
 					$order->addStatusHistoryComment(sprintf(
 						'<a target="_blank" href="%s">Clique aqui</a> para visualizar o boleto.',
 						$charge['print_url']

--- a/app/code/community/Vindi/Subscription/Model/CreditCard.php
+++ b/app/code/community/Vindi/Subscription/Model/CreditCard.php
@@ -37,7 +37,7 @@ class Vindi_Subscription_Model_CreditCard extends Vindi_Subscription_Model_Payme
 		if ('saved' === $data->getCcChoice()) {
 			$info->setAdditionalInformation('PaymentMethod', $this->_code)
 				->setAdditionalInformation('use_saved_cc', true)
-				->setAdditionalInformation('installments', $data->getCcInstallments());
+				->setAdditionalInformation('installments', $data->getCcInstallments() || 1);
 
 			return $this;
 		}
@@ -68,7 +68,7 @@ class Vindi_Subscription_Model_CreditCard extends Vindi_Subscription_Model_Payme
 		$verifyStatus = $this->api()->verifyCustomerPaymentProfile($paymentProfileId);
 		return ($verifyStatus['transaction']['status'] === 'success');
 	}
-	
+
 	/**
 	 * @param int $customerVindiId
 	 */
@@ -118,7 +118,7 @@ class Vindi_Subscription_Model_CreditCard extends Vindi_Subscription_Model_Payme
 				return 'Você deve informar o número de parcelas.';
 			}
 
-			if ($installments != 1) { 
+			if ($installments != 1) {
 				$maxInstallmentNumber = Mage::getStoreConfig('payment/vindi_creditcard/max_installments_number');
 
 				if ($installments > $maxInstallmentNumber) {

--- a/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
+++ b/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
@@ -378,7 +378,7 @@ trait Vindi_Subscription_Trait_PaymentProcessor
 
 			$paymentMethod = reset($payment['charges'])['payment_method']['type'];
 			if ($paymentMethod === 'PaymentMethod::BankSlip'
-                || $paymentMethod === 'PaymentMethod::OnlineBankSlip'
+				|| $paymentMethod === 'PaymentMethod::OnlineBankSlip'
 				|| $paymentMethod === 'PaymentMethod::DebitCard'
 				|| $billing_type !== 'beginning_of_period'
 				|| $payment['status'] === 'paid'

--- a/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
+++ b/app/code/community/Vindi/Subscription/Trait/PaymentProcessor.php
@@ -94,7 +94,7 @@ trait Vindi_Subscription_Trait_PaymentProcessor
 			$customer->loadByEmail($billing->getEmail());
 		}
 
-		//TODO fix user being created again if validation fails 
+		//TODO fix user being created again if validation fails
 		if (! ($userCode = $customer->getVindiUserCode())) {
 			$userCode = 'mag-' . $customer->getId() . '-' . time();
 
@@ -185,7 +185,7 @@ trait Vindi_Subscription_Trait_PaymentProcessor
 			$orderHandler = Mage::helper('vindi_subscription/order');
 			$orderHandler->updateToSuccess($order);
 			$stateObject->setStatus(Mage_Sales_Model_Order::STATE_PROCESSING)
-				->setState(Mage_Sales_Model_Order::STATE_PROCESSING); 
+				->setState(Mage_Sales_Model_Order::STATE_PROCESSING);
 
 			return $this;
 		}
@@ -204,7 +204,7 @@ trait Vindi_Subscription_Trait_PaymentProcessor
 
 		return $this->processSubscription($payment, $order, $customerId);
 	}
-	
+
 	/**
 	 * @param object $stateObject
 	 *
@@ -307,9 +307,9 @@ trait Vindi_Subscription_Trait_PaymentProcessor
 	protected function createSubscription($payment, $order, $customerId)
 	{
 		$orderItems = $order->getItemsCollection();
-		
+
 		foreach ($orderItems as $item) {
-			$plan = !empty($plan = $this->getCurrentVindiPlan($item)) ? $plan : null; 
+			$plan = !empty($plan = $this->getCurrentVindiPlan($item)) ? $plan : null;
 
 			if (null !== $plan) {
 				break;
@@ -378,6 +378,7 @@ trait Vindi_Subscription_Trait_PaymentProcessor
 
 			$paymentMethod = reset($payment['charges'])['payment_method']['type'];
 			if ($paymentMethod === 'PaymentMethod::BankSlip'
+                || $paymentMethod === 'PaymentMethod::OnlineBankSlip'
 				|| $paymentMethod === 'PaymentMethod::DebitCard'
 				|| $billing_type !== 'beginning_of_period'
 				|| $payment['status'] === 'paid'

--- a/tests/_support/Mage/Mage.php
+++ b/tests/_support/Mage/Mage.php
@@ -2,10 +2,17 @@
 
 class Mage
 {
+    public $version;
+
     public static function getStoreConfig($params)
     {
         if ('vindi_subscription/general/api_key' == $params)
             return getenv('VINDI_API_KEY');
+    }
+
+    public static function getConfig()
+    {
+        return new Mage();
     }
 
     public static function getUrl(...$params)
@@ -15,7 +22,7 @@ class Mage
 
     public static function helper($params)
     {
-        return __CLASS__;
+        return new Mage();
     }
 
     public static function getHash(...$params)
@@ -29,6 +36,36 @@ class Mage
     }
 
     public static function log()
+    {
+        return true;
+    }
+
+    public static function getModuleConfig($params)
+    {
+        return new Mage();
+    }
+
+    public static function getKey()
+    {
+        return new Mage();
+    }
+
+    public static function app()
+    {
+        return new Mage();
+    }
+
+    public static function getCache()
+    {
+        return new Mage();
+    }
+
+    public static function load()
+    {
+        return false;
+    }
+
+    public static function save()
     {
         return true;
     }

--- a/tests/_support/Responses.php
+++ b/tests/_support/Responses.php
@@ -1,0 +1,133 @@
+<?php
+
+class Responses
+{
+    const ACTIVE_BANKSLIP = array(
+        'payment_methods' => array(
+            array(
+                'name'        => 'Boleto bancário',
+                'type'        => 'PaymentMethod::BankSlip',
+                'status'      => 'active',
+                'code'        => 'bank_slip'
+            )
+        )
+    );
+    const ACTIVE_ONLINEBANKSLIP = array(
+        'payment_methods' => array(
+            array(
+                'name'        => 'Boleto bancário Online',
+                'type'        => 'PaymentMethod::OnlineBankSlip',
+                'status'      => 'active',
+                'code'        => 'bank_slip'
+                )
+            )
+    );
+
+    const ACTIVE_CREDITCARD = array(
+        'payment_methods' => array(
+            array(
+                'name'        => 'Cartão de Crédito',
+                'type'        => 'PaymentMethod::CreditCard',
+                'status'      => 'active',
+                'code'        => 'credit_card',
+                'payment_companies' => array(
+                    array(
+                        'name' => 'Mastercard',
+                        'code' => 'mastercard'
+                    ),
+                    array(
+                        'name' => 'Visa',
+                        'code' => 'visa'
+                    ),
+
+                    array(
+                        'name' => 'American Express',
+                        'code' => 'american_express'
+                    )
+                )
+            )
+        )
+    );
+    const ACTIVE_DEBITCARD = array(
+        'payment_methods' => array(
+            array(
+                'name'        => 'Cartão de Débito',
+                'type'        => 'PaymentMethod::DebitCard',
+                'status'      => 'active',
+                'code'        => 'debit_card',
+                'payment_companies' => array(
+                    array(
+                        'name' => 'Maestro',
+                        'code' => 'maestro'
+                    ),
+                    array(
+                        'name' => 'Visa Electron',
+                        'code' => 'visa_electron'
+                    ),
+
+                    array(
+                        'name' => 'Elo',
+                        'code' => 'elo_debit'
+                    )
+                )
+            )
+        )
+    );
+
+    const DEFAULT = array(
+        'payment_methods' => array(
+            array(
+                'name'        => 'Boleto bancário',
+                'type'        => 'PaymentMethod::BankSlip',
+                'status'      => 'active',
+                'code'        => 'bank_slip'
+            ),
+            array(
+                'name'        => 'Cartão de Crédito',
+                'type'        => 'PaymentMethod::CreditCard',
+                'status'      => 'active',
+                'code'        => 'credit_card',
+                'payment_companies' => array(
+                    array(
+                        'name' => 'Mastercard',
+                        'code' => 'mastercard'
+                    ),
+                    array(
+                        'name' => 'Visa',
+                        'code' => 'visa'
+                    ),
+
+                    array(
+                        'name' => 'American Express',
+                        'code' => 'american_express'
+                    )
+                )
+            ),
+            array(
+                'name'        => 'Cartão de Débito',
+                'type'        => 'PaymentMethod::DebitCard',
+                'status'      => 'active',
+                'code'        => 'debit_card',
+                'payment_companies' => array(
+                    array(
+                        'name' => 'Maestro',
+                        'code' => 'maestro'
+                    ),
+                    array(
+                        'name' => 'Visa Electron',
+                        'code' => 'visa_electron'
+                    ),
+
+                    array(
+                        'name' => 'Elo',
+                        'code' => 'elo_debit'
+                    )
+                )
+            )
+        )
+    );
+
+    const DEFAULTNULL = array(
+        'payment_methods' => array()
+    );
+}

--- a/tests/_support/Responses.php
+++ b/tests/_support/Responses.php
@@ -2,7 +2,7 @@
 
 class Responses
 {
-    const ACTIVE_BANKSLIP = array(
+    const ACTIVE_BANK_SLIP = array(
         'payment_methods' => array(
             array(
                 'name'        => 'Boleto bancário',
@@ -12,7 +12,7 @@ class Responses
             )
         )
     );
-    const ACTIVE_ONLINEBANKSLIP = array(
+    const ACTIVE_ONLINE_BANK_SLIP = array(
         'payment_methods' => array(
             array(
                 'name'        => 'Boleto bancário Online',
@@ -23,7 +23,7 @@ class Responses
             )
     );
 
-    const ACTIVE_CREDITCARD = array(
+    const ACTIVE_CREDIT_CARD = array(
         'payment_methods' => array(
             array(
                 'name'        => 'Cartão de Crédito',
@@ -48,7 +48,7 @@ class Responses
             )
         )
     );
-    const ACTIVE_DEBITCARD = array(
+    const ACTIVE_DEBIT_CARD = array(
         'payment_methods' => array(
             array(
                 'name'        => 'Cartão de Débito',
@@ -74,7 +74,7 @@ class Responses
         )
     );
 
-    const DEFAULT = array(
+    const GENERAL_PAYMENT_METHODS = array(
         'payment_methods' => array(
             array(
                 'name'        => 'Boleto bancário',
@@ -127,7 +127,7 @@ class Responses
         )
     );
 
-    const DEFAULTNULL = array(
+    const EMPTY_PAYMENT_METHODS = array(
         'payment_methods' => array()
     );
 }

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -2,6 +2,7 @@
 
 require 'Mage/Mage_Core_Helper_Abstract.php';
 require 'Mage/Mage.php';
+require 'app/code/community/Vindi/Subscription/Trait/LogMessenger.php';
 
 /**
  * Inherited Methods

--- a/tests/acceptance/vindiCheckoutWithBankSlipCest.php
+++ b/tests/acceptance/vindiCheckoutWithBankSlipCest.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 class VindiCheckoutWithBankSlipCest
 {

--- a/tests/acceptance/vindiCheckoutWithCreditCardCest.php
+++ b/tests/acceptance/vindiCheckoutWithCreditCardCest.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 class VindiCheckoutWithCreditCardCest
 {
@@ -122,6 +122,23 @@ class VindiCheckoutWithCreditCardCest
     public function buySubscriptionWithoutInstallment(AcceptanceTester $I)
     {
         $I->setDefaultCreditCard($I, false);
+        $I->loginAsUser($I);
+        $I->addSubscriptionToCart($I);
+        $I->click('Proceed to Checkout');
+        $I->skipCheckoutForm($I);
+        $I->waitForElement('#dt_method_vindi_creditcard', 30);
+        $I->selectOption('dl#checkout-payment-method-load', 'Cartão de Crédito');
+        $I->click('Continue', '#payment-buttons-container');
+        $I->waitForElement('#review-buttons-container', 30);
+        $I->click('Place Order');
+        $I->waitForElement('.main-container.col1-layout', 30);
+        $I->seeInCurrentUrl('/checkout/onepage/success');
+        $I->see('Your order has been received.');
+    }
+
+    public function buyProductInInstallmentsOneWithSavedCreditCard(AcceptanceTester $I)
+    {
+        $I->setDefaultCreditCard($I, true, 1);
         $I->loginAsUser($I);
         $I->addSubscriptionToCart($I);
         $I->click('Proceed to Checkout');

--- a/tests/acceptance/vindiCheckoutWithCreditCardCest.php
+++ b/tests/acceptance/vindiCheckoutWithCreditCardCest.php
@@ -180,21 +180,4 @@ class VindiCheckoutWithCreditCardCest
         if ($bill['installments'] != $installments)
             throw new \RuntimeException;
     }
-
-    public function buyProductInInstallmentsOneWithSavedCreditCard(AcceptanceTester $I)
-    {
-        $I->setDefaultCreditCard($I, true, $installments);
-        $I->loginAsUser($I);
-        $I->addSubscriptionToCart($I);
-        $I->click('Proceed to Checkout');
-        $I->skipCheckoutForm($I);
-        $I->waitForElement('#dt_method_vindi_creditcard', 30);
-        $I->selectOption('dl#checkout-payment-method-load', 'Cartão de Crédito');
-        $I->click('Continue', '#payment-buttons-container');
-        $I->waitForElement('#review-buttons-container', 30);
-        $I->click('Place Order');
-        $I->waitForElement('.main-container.col1-layout', 30);
-        $I->seeInCurrentUrl('/checkout/onepage/success');
-        $I->see('Your order has been received.');
-    }
 }

--- a/tests/acceptance/vindiCheckoutWithCreditCardCest.php
+++ b/tests/acceptance/vindiCheckoutWithCreditCardCest.php
@@ -183,7 +183,7 @@ class VindiCheckoutWithCreditCardCest
 
     public function buyProductInInstallmentsOneWithSavedCreditCard(AcceptanceTester $I)
     {
-        $I->setDefaultCreditCard($I, true, 1);
+        $I->setDefaultCreditCard($I, true, $installments);
         $I->loginAsUser($I);
         $I->addSubscriptionToCart($I);
         $I->click('Proceed to Checkout');

--- a/tests/acceptance/vindiCreditCardSettingsCest.php
+++ b/tests/acceptance/vindiCreditCardSettingsCest.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 class VindiCreditCardSettingsCest
 {

--- a/tests/acceptance/vindiModuleConfigCest.php
+++ b/tests/acceptance/vindiModuleConfigCest.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 class VindiModuleConfigCest
 {

--- a/tests/unit/ApiTest.php
+++ b/tests/unit/ApiTest.php
@@ -32,51 +32,49 @@ class ApiTest extends \Codeception\Test\Unit
 
     public function testGetPaymentMethodBankSlip()
     {
-      $dummy_connector_class = $this->make(
-          'Vindi_Subscription_Helper_Connector',
-          [
-              'get' => $this->response::ACTIVE_BANK_SLIP
-          ]
-      );
-      $dummy_class = $this->make(
-          'Vindi_Subscription_Helper_API',
-          [
-              'connector' => $dummy_connector_class
-          ],
-
-      );
-      $success = array(
+        $dummy_connector_class = $this->make(
+            'Vindi_Subscription_Helper_Connector',
+            [
+                'get' => $this->response::ACTIVE_BANK_SLIP
+            ]
+        );
+        $dummy_class = $this->make(
+            'Vindi_Subscription_Helper_API',
+            [
+                'connector' => $dummy_connector_class
+            ],
+        );
+        $success = array(
           'credit_card' => [],
           'debit_card' => [],
           'bank_slip'   => true
       );
 
-      $this->assertEquals($dummy_class->getPaymentMethods(), $success);
-  }
+        $this->assertEquals($dummy_class->getPaymentMethods(), $success);
+    }
 
     public function testGetPaymentMethodOnlineBankSlip()
     {
-    $dummy_connector_class = $this->make(
-        'Vindi_Subscription_Helper_Connector',
-        [
-            'get' => $this->response::ACTIVE_ONLINE_BANK_SLIP
-        ]
-    );
-    $dummy_class = $this->make(
-        'Vindi_Subscription_Helper_API',
-        [
-            'connector' => $dummy_connector_class
-        ],
+        $dummy_connector_class = $this->make(
+            'Vindi_Subscription_Helper_Connector',
+            [
+                'get' => $this->response::ACTIVE_ONLINE_BANK_SLIP
+            ]
+        );
+        $dummy_class = $this->make(
+            'Vindi_Subscription_Helper_API',
+            [
+                'connector' => $dummy_connector_class
+            ],
+        );
+        $success = array(
+            'credit_card' => [],
+            'debit_card' => [],
+            'bank_slip'   => true
+        );
 
-    );
-    $success = array(
-        'credit_card' => [],
-        'debit_card' => [],
-        'bank_slip'   => true
-    );
-
-    $this->assertEquals($dummy_class->getPaymentMethods(), $success);
-  }
+        $this->assertEquals($dummy_class->getPaymentMethods(), $success);
+    }
 
     public function testGetPaymentMethodCreditCard()
     {
@@ -91,7 +89,6 @@ class ApiTest extends \Codeception\Test\Unit
             [
                 'connector' => $dummy_connector_class
             ],
-
         );
         $success = array(
             'credit_card' => array(
@@ -128,7 +125,6 @@ class ApiTest extends \Codeception\Test\Unit
             [
                 'connector' => $dummy_connector_class
             ],
-
         );
         $success = array(
             'credit_card' => [],
@@ -225,5 +221,4 @@ class ApiTest extends \Codeception\Test\Unit
 
         $this->assertEquals($dummy_class->getPaymentMethods(), $success);
     }
-
 }

--- a/tests/unit/ApiTest.php
+++ b/tests/unit/ApiTest.php
@@ -1,0 +1,180 @@
+<?php
+require_once 'app/code/community/Vindi/Subscription/Helper/Api.php';
+
+class ApiTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+
+    /**
+     * @var \Vindi_Subscription_Helper_API
+     */
+    protected $api;
+
+    /**
+     * @var \Responses
+     */
+    protected $response;
+
+    protected function _before()
+    {
+        $this->api = new Vindi_Subscription_Helper_API();
+        $this->response = new Responses();
+    }
+
+    public function testGetPaymentMethodBankSlip()
+    {
+      $dummy_class = $this->make(
+          'Vindi_Subscription_Helper_API',
+          [
+              'request' => $this->response::ACTIVE_BANKSLIP
+          ]
+      );
+      $success = array(
+          'credit_card' => [],
+          'debit_card' => [],
+          'bank_slip'   => true
+      );
+
+      $this->assertEquals($dummy_class->getPaymentMethods(), $success);
+  }
+
+    public function testGetPaymentMethodOnlineBankSlip()
+    {
+    $dummy_class = $this->make(
+        'Vindi_Subscription_Helper_API',
+        [
+            'request' => $this->response::ACTIVE_ONLINEBANKSLIP
+        ]
+    );
+    $success = array(
+        'credit_card' => [],
+        'debit_card' => [],
+        'bank_slip'   => true
+    );
+
+    $this->assertEquals($dummy_class->getPaymentMethods(), $success);
+  }
+
+    public function testGetPaymentMethodCreditCard()
+    {
+        $dummy_class = $this->make(
+            'Vindi_Subscription_Helper_API',
+            [
+                'request' => $this->response::ACTIVE_CREDITCARD
+            ]
+        );
+        $success = array(
+            'credit_card' => array(
+                array(
+                    'name' => 'Mastercard',
+                    'code' => 'mastercard'
+                ),
+                array(
+                    'name' => 'Visa',
+                    'code' => 'visa'
+                ),
+                array(
+                    'name' => 'American Express',
+                    'code' => 'american_express'
+                )
+            ),
+            'debit_card' => [],
+            'bank_slip'   => false
+        );
+
+        $this->assertEquals($dummy_class->getPaymentMethods(), $success);
+    }
+
+    public function testGetPaymentMethodDebitCard()
+    {
+        $dummy_class = $this->make(
+            'Vindi_Subscription_Helper_API',
+            [
+                'request' => $this->response::ACTIVE_DEBITCARD
+            ]
+        );
+        $success = array(
+            'credit_card' => [],
+            'debit_card' => array(
+                array(
+                    'name' => 'Maestro',
+                    'code' => 'maestro'
+                ),
+                array(
+                    'name' => 'Visa Electron',
+                    'code' => 'visa_electron'
+                ),
+                array(
+                    'name' => 'Elo',
+                    'code' => 'elo_debit'
+                )
+            ),
+            'bank_slip'   => false
+        );
+
+        $this->assertEquals($dummy_class->getPaymentMethods(), $success);
+    }
+
+    public function testGetDefaultPaymentMethods()
+    {
+        $dummy_class = $this->make(
+            'Vindi_Subscription_Helper_API',
+            [
+                'request' => $this->response::DEFAULT
+            ]
+        );
+        $success = array(
+            'credit_card' => array(
+                array(
+                    'name' => 'Mastercard',
+                    'code' => 'mastercard'
+                ),
+                array(
+                    'name' => 'Visa',
+                    'code' => 'visa'
+                ),
+                array(
+                    'name' => 'American Express',
+                    'code' => 'american_express'
+                )
+            ),
+            'debit_card' => array(
+                array(
+                    'name' => 'Maestro',
+                    'code' => 'maestro'
+                ),
+                array(
+                    'name' => 'Visa Electron',
+                    'code' => 'visa_electron'
+                ),
+                array(
+                    'name' => 'Elo',
+                    'code' => 'elo_debit'
+                )
+            ),
+            'bank_slip'   => true
+        );
+
+        $this->assertEquals($dummy_class->getPaymentMethods(), $success);
+    }
+
+    public function testGetDefaultPaymentMethodsNull()
+    {
+        $dummy_class = $this->make(
+            'Vindi_Subscription_Helper_API',
+            [
+                'request' => $this->response::DEFAULTNULL
+            ]
+        );
+        $success = array(
+            'credit_card' => [],
+            'debit_card'  => [],
+            'bank_slip'   => false
+        );
+
+        $this->assertEquals($dummy_class->getPaymentMethods(), $success);
+    }
+}

--- a/tests/unit/ApiTest.php
+++ b/tests/unit/ApiTest.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'app/code/community/Vindi/Subscription/Helper/Api.php';
+require_once 'app/code/community/Vindi/Subscription/Helper/Connector.php';
 
 class ApiTest extends \Codeception\Test\Unit
 {
@@ -18,6 +19,11 @@ class ApiTest extends \Codeception\Test\Unit
      */
     protected $response;
 
+    /**
+     * @var \Connector
+     */
+    protected $connector;
+
     protected function _before()
     {
         $this->api = new Vindi_Subscription_Helper_API();
@@ -26,11 +32,18 @@ class ApiTest extends \Codeception\Test\Unit
 
     public function testGetPaymentMethodBankSlip()
     {
+      $dummy_connector_class = $this->make(
+          'Vindi_Subscription_Helper_Connector',
+          [
+              'get' => $this->response::ACTIVE_BANK_SLIP
+          ]
+      );
       $dummy_class = $this->make(
           'Vindi_Subscription_Helper_API',
           [
-              'request' => $this->response::ACTIVE_BANKSLIP
-          ]
+              'connector' => $dummy_connector_class
+          ],
+
       );
       $success = array(
           'credit_card' => [],
@@ -43,11 +56,18 @@ class ApiTest extends \Codeception\Test\Unit
 
     public function testGetPaymentMethodOnlineBankSlip()
     {
+    $dummy_connector_class = $this->make(
+        'Vindi_Subscription_Helper_Connector',
+        [
+            'get' => $this->response::ACTIVE_ONLINE_BANK_SLIP
+        ]
+    );
     $dummy_class = $this->make(
         'Vindi_Subscription_Helper_API',
         [
-            'request' => $this->response::ACTIVE_ONLINEBANKSLIP
-        ]
+            'connector' => $dummy_connector_class
+        ],
+
     );
     $success = array(
         'credit_card' => [],
@@ -60,11 +80,18 @@ class ApiTest extends \Codeception\Test\Unit
 
     public function testGetPaymentMethodCreditCard()
     {
+        $dummy_connector_class = $this->make(
+            'Vindi_Subscription_Helper_Connector',
+            [
+                'get' => $this->response::ACTIVE_CREDIT_CARD
+            ]
+        );
         $dummy_class = $this->make(
             'Vindi_Subscription_Helper_API',
             [
-                'request' => $this->response::ACTIVE_CREDITCARD
-            ]
+                'connector' => $dummy_connector_class
+            ],
+
         );
         $success = array(
             'credit_card' => array(
@@ -90,11 +117,18 @@ class ApiTest extends \Codeception\Test\Unit
 
     public function testGetPaymentMethodDebitCard()
     {
+        $dummy_connector_class = $this->make(
+            'Vindi_Subscription_Helper_Connector',
+            [
+                'get' => $this->response::ACTIVE_DEBIT_CARD
+            ]
+        );
         $dummy_class = $this->make(
             'Vindi_Subscription_Helper_API',
             [
-                'request' => $this->response::ACTIVE_DEBITCARD
-            ]
+                'connector' => $dummy_connector_class
+            ],
+
         );
         $success = array(
             'credit_card' => [],
@@ -120,11 +154,18 @@ class ApiTest extends \Codeception\Test\Unit
 
     public function testGetDefaultPaymentMethods()
     {
+        $dummy_connector_class = $this->make(
+            'Vindi_Subscription_Helper_Connector',
+            [
+                'get' => $this->response::GENERAL_PAYMENT_METHODS
+            ]
+        );
         $dummy_class = $this->make(
             'Vindi_Subscription_Helper_API',
             [
-                'request' => $this->response::DEFAULT
-            ]
+                'connector' => $dummy_connector_class
+            ],
+
         );
         $success = array(
             'credit_card' => array(
@@ -163,11 +204,18 @@ class ApiTest extends \Codeception\Test\Unit
 
     public function testGetDefaultPaymentMethodsNull()
     {
+        $dummy_connector_class = $this->make(
+            'Vindi_Subscription_Helper_Connector',
+            [
+                'get' => $this->response::EMPTY_PAYMENT_METHODS
+            ]
+        );
         $dummy_class = $this->make(
             'Vindi_Subscription_Helper_API',
             [
-                'request' => $this->response::DEFAULTNULL
-            ]
+                'connector' => $dummy_connector_class
+            ],
+
         );
         $success = array(
             'credit_card' => [],
@@ -177,4 +225,5 @@ class ApiTest extends \Codeception\Test\Unit
 
         $this->assertEquals($dummy_class->getPaymentMethods(), $success);
     }
+
 }

--- a/tests/unit/ApiTest.php
+++ b/tests/unit/ApiTest.php
@@ -5,28 +5,12 @@ require_once 'app/code/community/Vindi/Subscription/Helper/Connector.php';
 class ApiTest extends \Codeception\Test\Unit
 {
     /**
-     * @var \UnitTester
-     */
-    protected $tester;
-
-    /**
-     * @var \Vindi_Subscription_Helper_API
-     */
-    protected $api;
-
-    /**
      * @var \Responses
      */
     protected $response;
 
-    /**
-     * @var \Connector
-     */
-    protected $connector;
-
     protected function _before()
     {
-        $this->api = new Vindi_Subscription_Helper_API();
         $this->response = new Responses();
     }
 

--- a/tests/unit/ValidatorTest.php
+++ b/tests/unit/ValidatorTest.php
@@ -1,15 +1,10 @@
-<?php 
+<?php
 require_once 'app/code/community/Vindi/Subscription/Trait/LogMessenger.php';
 require_once 'app/code/community/Vindi/Subscription/Helper/Bill.php';
 require_once 'app/code/community/Vindi/Subscription/Helper/Order.php';
 
 class ValidatorTest extends \Codeception\Test\Unit
 {
-    /**
-     * @var \UnitTester
-     */
-    protected $tester;
-
     /**
      * @var \Webhook
      */
@@ -19,7 +14,7 @@ class ValidatorTest extends \Codeception\Test\Unit
      * @var \Vindi_Subscription_Helper_Validator
      */
     protected $validator;
-    
+
     protected function _before()
     {
         $this->validator = new Vindi_Subscription_Helper_Validator();

--- a/tests/unit/WebhookHandlerTest.php
+++ b/tests/unit/WebhookHandlerTest.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 require_once 'app/code/community/Vindi/Subscription/Trait/LogMessenger.php';
 require_once 'app/code/community/Vindi/Subscription/Trait/ExceptionMessenger.php';
 require_once 'app/code/community/Vindi/Subscription/Helper/WebhookHandler.php';
@@ -7,23 +7,12 @@ require_once 'app/code/community/Vindi/Subscription/Helper/Validator.php';
 class WebhookHandlerTest extends \Codeception\Test\Unit
 {
     /**
-     * @var \UnitTester
-     */
-    protected $tester;
-
-    /**
      * @var \Webhook
      */
     protected $webhooks;
 
-    /**
-     * @var \Vindi_Subscription_Helper_WebhookHandler
-     */
-    protected $webhook_handler;
-    
     protected function _before()
     {
-        $this->webhook_handler = new Vindi_Subscription_Helper_WebhookHandler();
         $this->webhooks = new Webhooks();
     }
 


### PR DESCRIPTION
## Motivação
Atualmente, o módulo do Magento valida se a plataforma origem da chave de API possui um método de pagamento com o tipo "BankSlip". Caso o cliente não possua, o pagamento será rejeitado em tela.
Ou seja, caso o cliente só possua um boleto do tipo "OnlineBankSlip" em sua plataforma, nunca será possível finalizar a compra.

## Solução Proposta
Adicionei uma condição para validar também o boleto Webservice.

## Como testar
No ambiente da Vindi, certifique-se de ter apenas um método de boleto bancário ativo e que o mesmo seja o online:

![image](https://user-images.githubusercontent.com/50752933/64255392-aad76e80-cef7-11e9-9da9-64d7626506e9.png)

Após isso, faça uma compra no ambiente Magento:

![image](https://user-images.githubusercontent.com/50752933/64263244-b467d300-cf05-11e9-95e4-8643ddd9462d.png)

Antes dessa solução, o erro seguinte era apresentado em tela:

![image](https://user-images.githubusercontent.com/50752933/64263293-c77aa300-cf05-11e9-9798-ab856600868e.png)
