### PR TITLE
adicionando configuração para o semaphore 2.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -19,7 +19,7 @@ blocks:
             - echo $BRANCH_NAME
             - echo $SEMAPHORE_GIT_BRANCH
             - echo 'testando 2'
-            - docker exec -it magento1_web modgit add -b "$BRANCH_NAME" vindi https://github.com/vindi/vindi-magento.git
+            - docker exec -it magento1_web modgit add -b "$SEMAPHORE_GIT_BRANCH" vindi https://github.com/vindi/vindi-magento.git
             - sudo sh -c "echo '127.0.0.1 vindi.magento' >> /etc/hosts"
             - composer install
             - sleep 10 && docker exec -it magento1_web php -r 'require "app/Mage.php"; Mage::app()->getCacheInstance()->flush();'

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -15,10 +15,6 @@ blocks:
             - checkout
             - cache restore
             - docker network create webproxy && docker-compose up -d
-            - echo 'testando 1'
-            - echo $BRANCH_NAME
-            - echo $SEMAPHORE_GIT_BRANCH
-            - echo 'testando 2'
             - docker exec -it magento1_web modgit add -b "$SEMAPHORE_GIT_BRANCH" vindi https://github.com/vindi/vindi-magento.git
             - sudo sh -c "echo '127.0.0.1 vindi.magento' >> /etc/hosts"
             - composer install
@@ -33,4 +29,5 @@ blocks:
           commands:
             - cache restore
             - if [ $SEMAPHORE_GIT_BRANCH = 'master' ]; then  composer test acceptance; else true; fi
-            - composer test unit
+#            - composer test unit
+            - codecept test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -30,6 +30,6 @@ blocks:
           commands:
             - 'if [ $SEMAPHORE_GIT_BRANCH = ''master'' ]; then  composer test acceptance; else true; fi'
             - composer test unit
-      env_vars:
-        - name: VINDI_API_KEY
-          value: beJqWzrY6f1eqVuAaK3KbRvxvqzMsAM_AR0xdbWSM8E
+      env_vars: []
+      secrets:
+        - name: vindi_sandbox_api_key

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,31 @@
+# Documentação sobre Semaphore 2.0 com Ubuntu:
+# https://docs.semaphoreci.com/programming-languages/php/
+version: v1.0
+name: vindi-magento
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Setup
+    task:
+      jobs:
+        - name: Setup
+          commands:
+            - checkout
+            - cache restore
+            - docker network create webproxy && docker-compose up -d
+            - docker exec -it magento1_web modgit add -b "$BRANCH_NAME" vindi https://github.com/vindi/vindi-magento.git
+            - sudo sh -c "echo '127.0.0.1 vindi.magento' >> /etc/hosts"
+            - composer install
+            - sleep 10 && docker exec -it magento1_web php -r 'require "app/Mage.php"; Mage::app()->getCacheInstance()->flush();'
+            - chromedriver --url-base=/wd/hub & sleep 5
+            - cache store
+  - name: Test
+    task:
+      jobs:
+        - name: Test
+          commands:
+            - cache restore
+            - if [ $SEMAPHORE_GIT_BRANCH = 'master' ]; then  composer test acceptance; else true; fi
+            - composer test unit

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,6 +21,7 @@ blocks:
             - sleep 10 && docker exec -it magento1_web php -r 'require "app/Mage.php"; Mage::app()->getCacheInstance()->flush();'
             - chromedriver --url-base=/wd/hub & sleep 5
             - cache store
+
   - name: Test
     task:
       jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,5 +1,3 @@
-# Documentação sobre Semaphore 2.0 com Ubuntu:
-# https://docs.semaphoreci.com/programming-languages/php/
 version: v1.0
 name: vindi-magento
 agent:
@@ -15,13 +13,12 @@ blocks:
             - checkout
             - cache restore
             - docker network create webproxy && docker-compose up -d
-            - docker exec -it magento1_web modgit add -b "$SEMAPHORE_GIT_BRANCH" vindi https://github.com/vindi/vindi-magento.git
+            - 'docker exec -it magento1_web modgit add -b "$SEMAPHORE_GIT_BRANCH" vindi https://github.com/vindi/vindi-magento.git'
             - sudo sh -c "echo '127.0.0.1 vindi.magento' >> /etc/hosts"
             - composer install
-            - sleep 10 && docker exec -it magento1_web php -r 'require "app/Mage.php"; Mage::app()->getCacheInstance()->flush();'
+            - 'sleep 10 && docker exec -it magento1_web php -r ''require "app/Mage.php"; Mage::app()->getCacheInstance()->flush();'''
             - chromedriver --url-base=/wd/hub & sleep 5
             - cache store
-
   - name: Test
     task:
       prologue:
@@ -31,5 +28,8 @@ blocks:
       jobs:
         - name: Test
           commands:
-            - if [ $SEMAPHORE_GIT_BRANCH = 'master' ]; then  composer test acceptance; else true; fi
+            - 'if [ $SEMAPHORE_GIT_BRANCH = ''master'' ]; then  composer test acceptance; else true; fi'
             - composer test unit
+      env_vars:
+        - name: VINDI_API_KEY
+          value: beJqWzrY6f1eqVuAaK3KbRvxvqzMsAM_AR0xdbWSM8E

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,6 +24,12 @@ blocks:
 
   - name: Test
     task:
+      prologue:
+        commands:
+          - checkout
+          - cache restore
+          # Prepend vendor/bin to the path so you can use dependency executables
+          - export "PATH=./vendor/bin:${PATH}"            
       jobs:
         - name: Test
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,6 +18,7 @@ blocks:
             - docker exec -it magento1_web modgit add -b "$SEMAPHORE_GIT_BRANCH" vindi https://github.com/vindi/vindi-magento.git
             - sudo sh -c "echo '127.0.0.1 vindi.magento' >> /etc/hosts"
             - composer install
+            - codecept test
             - sleep 10 && docker exec -it magento1_web php -r 'require "app/Mage.php"; Mage::app()->getCacheInstance()->flush();'
             - chromedriver --url-base=/wd/hub & sleep 5
             - cache store
@@ -35,5 +36,5 @@ blocks:
           commands:
             - cache restore
             - if [ $SEMAPHORE_GIT_BRANCH = 'master' ]; then  composer test acceptance; else true; fi
-#            - composer test unit
-            - codecept test
+            - composer test unit
+#            - codecept test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -15,6 +15,8 @@ blocks:
             - checkout
             - cache restore
             - docker network create webproxy && docker-compose up -d
+            - echo $BRANCH_NAME
+            - echo 'testando'
             - docker exec -it magento1_web modgit add -b "$BRANCH_NAME" vindi https://github.com/vindi/vindi-magento.git
             - sudo sh -c "echo '127.0.0.1 vindi.magento' >> /etc/hosts"
             - composer install

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,13 +22,12 @@ blocks:
             - chromedriver --url-base=/wd/hub & sleep 5
             - cache store
 
-  - name: Setup and Test
+  - name: Test
     task:
       prologue:
         commands:
           - checkout
           - cache restore
-#          - export "PATH=./vendor/bin:${PATH}"            
       jobs:
         - name: Test
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,23 +18,19 @@ blocks:
             - docker exec -it magento1_web modgit add -b "$SEMAPHORE_GIT_BRANCH" vindi https://github.com/vindi/vindi-magento.git
             - sudo sh -c "echo '127.0.0.1 vindi.magento' >> /etc/hosts"
             - composer install
-#            - composer test unit
             - sleep 10 && docker exec -it magento1_web php -r 'require "app/Mage.php"; Mage::app()->getCacheInstance()->flush();'
             - chromedriver --url-base=/wd/hub & sleep 5
             - cache store
 
-  - name: Test
+  - name: Setup and Test
     task:
       prologue:
         commands:
           - checkout
           - cache restore
-          # Prepend vendor/bin to the path so you can use dependency executables
-          - export "PATH=./vendor/bin:${PATH}"            
+#          - export "PATH=./vendor/bin:${PATH}"            
       jobs:
         - name: Test
           commands:
-#            - cache restore
             - if [ $SEMAPHORE_GIT_BRANCH = 'master' ]; then  composer test acceptance; else true; fi
             - composer test unit
-#            - codecept test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,7 +18,7 @@ blocks:
             - docker exec -it magento1_web modgit add -b "$SEMAPHORE_GIT_BRANCH" vindi https://github.com/vindi/vindi-magento.git
             - sudo sh -c "echo '127.0.0.1 vindi.magento' >> /etc/hosts"
             - composer install
-            - composer test unit
+#            - composer test unit
             - sleep 10 && docker exec -it magento1_web php -r 'require "app/Mage.php"; Mage::app()->getCacheInstance()->flush();'
             - chromedriver --url-base=/wd/hub & sleep 5
             - cache store

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,7 +18,7 @@ blocks:
             - docker exec -it magento1_web modgit add -b "$SEMAPHORE_GIT_BRANCH" vindi https://github.com/vindi/vindi-magento.git
             - sudo sh -c "echo '127.0.0.1 vindi.magento' >> /etc/hosts"
             - composer install
-            - codecept test
+            - composer test unit
             - sleep 10 && docker exec -it magento1_web php -r 'require "app/Mage.php"; Mage::app()->getCacheInstance()->flush();'
             - chromedriver --url-base=/wd/hub & sleep 5
             - cache store

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -34,7 +34,7 @@ blocks:
       jobs:
         - name: Test
           commands:
-            - cache restore
+#            - cache restore
             - if [ $SEMAPHORE_GIT_BRANCH = 'master' ]; then  composer test acceptance; else true; fi
             - composer test unit
 #            - codecept test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -15,8 +15,10 @@ blocks:
             - checkout
             - cache restore
             - docker network create webproxy && docker-compose up -d
+            - echo 'testando 1'
             - echo $BRANCH_NAME
-            - echo 'testando'
+            - echo $SEMAPHORE_GIT_BRANCH
+            - echo 'testando 2'
             - docker exec -it magento1_web modgit add -b "$BRANCH_NAME" vindi https://github.com/vindi/vindi-magento.git
             - sudo sh -c "echo '127.0.0.1 vindi.magento' >> /etc/hosts"
             - composer install


### PR DESCRIPTION
## Motivação :muscle:

Habilitar o projeto para usar a versão 2.0 do Semaphore CI conforme a issue https://github.com/vindi/vindi-magento/issues/135

## Solução proposta :wrench:

Criar arquivo de configuração (YAML) do serviço no projeto

## Como testar :policeman:

Abrir a intrface 2.0 do Semaphore e fazer o build.

## Riscos :warning:

Sem riscos

## Impactos previstos :boom:

Sem impactos

## Requisitos para deploy :game_die:

Ter a entrada do projeto no Semaphore 2.0 criada