### PR TITLE
Corrige duplicidade de produtos configuráveis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Notas das versões
 
+## [1.8.10 - 11/03/2021](https://github.com/vindi/vindi-magento/releases/tag/1.8.10)
+
+### Corrigido
+- Corrige duplicidade de produtos configuráveis
+
 ## [1.8.9 - 31/10/2019](https://github.com/vindi/vindi-magento/releases/tag/1.8.9)
 
 ### Corrigido

--- a/app/code/community/Vindi/Subscription/Helper/Api.php
+++ b/app/code/community/Vindi/Subscription/Helper/Api.php
@@ -560,7 +560,7 @@ class Vindi_Subscription_Helper_API extends Vindi_Subscription_Helper_Connector
     public function findOrCreateUniquePaymentProduct($order)
     {
         $billItems = array();
-        foreach ($order->getItemsCollection() as $item) {
+        foreach ($order->getAllVisibleItems() as $item) {
             $productId = $this->findOrCreateProduct(
                 array(
                     'sku' => $item->getSku(),


### PR DESCRIPTION
by: @brunoconstantino

## O que mudou
Agora não será mais enviado um produto com valor zerado para a Vindi caso seja efetuada uma compra de produto configurável.

## Motivação
Na issue https://github.com/vindi/vindi-magento/issues/133, foi reportado um problema em que estão sendo colocados produtos a mais na fatura do cliente caso o produto comprado seja um produto configurável.

## Solução proposta
Estou alterando o método de criação de faturas avulsas para `$order->getAllVisibleItems()`, que só utilizará o produto principal na criação da fatura.

## Como testar
- Crie um produto configurável no seu ambiente Magento
- Realize a compra de uma variação
- Ao verificar a plataforma Vindi, a fatura criada deve estar da seguinte forma:

![image](https://user-images.githubusercontent.com/50752933/110536482-47d42280-8100-11eb-98aa-a915b712db58.png)

Antes da correção, a fatura estará assim:

![image](https://user-images.githubusercontent.com/50752933/110536526-54587b00-8100-11eb-9514-298ce3bdb91d.png)

