### PR TITLE
Atualiza versão do user agent

### DIFF
--- a/app/code/community/Vindi/Subscription/etc/config.xml
+++ b/app/code/community/Vindi/Subscription/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Vindi_Subscription>
-            <version>1.8.9</version>
+            <version>1.8.10</version>
         </Vindi_Subscription>
     </modules>
     <global>


### PR DESCRIPTION
## O que mudou
É necessário alterar o user-agent para a nova versão do Magento (1.8.10)

## Motivação
O arquivo `config.xml` está desatualizado.

## Solução proposta
Atualização da versão do arquivo `config.xml`

